### PR TITLE
chore: 添加Github Actions构建工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Application EXE
+on:
+  release:
+    types: [created]
+jobs:
+   build:
+    runs-on: windows-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pyinstaller
+    - name: Build with Pyinstaller
+      run: |
+        $ttkbootstrap_path = (Get-Command pip).path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"
+        pyinstaller --noconfirm --onefile --windowed --name "B站弹幕补档工具" `
+          --icon="assets/icon.ico" `
+          --add-data "$ttkbootstrap_path;ttkbootstrap" `
+          gui.py
+          
+    - name: Upload EXE artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }} 
+        asset_name: B站弹幕补档工具-v${{ github.ref_name }}.exe
+        asset_path: ./dist/B站弹幕补档工具.exe
+        asset_content_type: application/vnd.microsoft.portable-executable


### PR DESCRIPTION
## Sourcery 总结

添加一个 GitHub Actions 工作流，以便在新版本发布时自动构建并上传 Windows 可执行文件。

构建：
- 创建一个在发布创建时触发的 build.yml 工作流
- 设置一个带有 Python 3.12 的 Windows runner 并安装项目依赖
- 使用 PyInstaller 将应用程序打包成一个单独的可执行文件
- 将生成的 EXE 作为发布资产上传

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a GitHub Actions workflow to automatically build and upload a Windows executable on new releases.

Build:
- Create a build.yml workflow that triggers on release creation
- Set up a Windows runner with Python 3.12 and install project dependencies
- Use PyInstaller to package the application into a single executable
- Upload the generated EXE as a release asset

</details>