### PR TITLE
fix(ci): Grant contents write permission for release asset upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 jobs:
    build:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
     - name: Check out repository code
       uses: actions/checkout@v4
@@ -31,6 +33,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }} 
-        asset_name: B站弹幕补档工具-v${{ github.ref_name }}.exe
+        asset_name: B站弹幕补档工具-${{ github.ref_name }}.exe
         asset_path: ./dist/B站弹幕补档工具.exe
         asset_content_type: application/vnd.microsoft.portable-executable


### PR DESCRIPTION
## Sourcery 总结

修复 CI 工作流，通过授予写入权限并标准化资产文件名，以正确上传发布资产

Bug 修复:
- 在 GitHub Actions 工作流中启用内容写入权限，以允许发布资产上传
- 从生成的发布资产文件名中移除开头的 "v"，以保持一致性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix CI workflow to properly upload release assets by granting write permission and standardize the asset filename

Bug Fixes:
- Enable contents write permission in the GitHub Actions workflow to allow release asset uploads
- Remove the leading "v" from the generated release asset filename for consistency

</details>