### PR TITLE
feat(ci): Attempt to use Chinese filename for build and release asset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
 jobs:
    build:
     runs-on: windows-latest
+    # 强制在整个 job 中使用 PowerShell Core (pwsh)
+    # 这通常对中文字符支持最好
+    defaults:
+      run:
+        shell: pwsh
     permissions:
       contents: write
     steps:
@@ -20,19 +25,31 @@ jobs:
         pip install -r requirements.txt
         pip install pyinstaller
     - name: Build with Pyinstaller
+      # 尝试使用中文名
       run: |
         $ttkbootstrap_path = (Get-Command pip).path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"
+        # 注意：这里需要确保你的 shell 能够正确处理传递的中文参数
         pyinstaller --noconfirm --onefile --windowed --name "B站弹幕补档工具" `
           --icon="assets/icon.ico" `
           --add-data "$ttkbootstrap_path;ttkbootstrap" `
           gui.py
-          
+
+    # IMPORTANT: 增加一个调试步骤，查看 dist 目录下的文件
+    - name: Debug - List contents of dist directory
+      run: Get-ChildItem -Path ./dist
+      # 或者使用 dir ./dist 如果你的 shell 最终不是 pwsh
+
     - name: Upload EXE artifact
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }} 
-        asset_name: B站弹幕补档工具-${{ github.ref_name }}.exe
+        upload_url: ${{ github.event.release.upload_url }}
+        # 这里的 asset_name 是显示在 GitHub Release 页面上的名称
+        # 如果 PyInstaller 成功生成了中文名，这里也用中文名
+        asset_name: B站弹幕补档工具-v${{ github.ref_name }}.exe
+        # 这里的 asset_path 必须与 PyInstaller 实际生成的文件名完全匹配
+        # 这就是 Debug 步骤的关键所在
         asset_path: ./dist/B站弹幕补档工具.exe
         asset_content_type: application/vnd.microsoft.portable-executable
+


### PR DESCRIPTION
## Sourcery 总结

在 CI 构建中使用 PowerShell Core 以更好地支持中文文件名，尝试生成并上传一个中文命名的可执行文件，并添加一个调试步骤以检查构建产物。

CI:
- 强制整个构建作业在 pwsh 下运行，以正确处理中文字符
- 添加一个调试步骤，用于在构建后列出 dist 目录的内容
- 更新发布上传步骤，以使用带有版本前缀和匹配资产路径的中文命名可执行文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use PowerShell Core for better Chinese filename support in the CI build, attempt to generate and upload a Chinese-named executable, and add a debug step to inspect build artifacts.

CI:
- Force the entire build job to run under pwsh to handle Chinese characters correctly
- Add a debug step to list the contents of the dist directory after building
- Update the release upload step to use a Chinese-named executable with version prefix and matching asset path

</details>