### PR TITLE
feat: 实现健壮的错误处理机制

### DIFF
--- a/bili_danmaku_utils.py
+++ b/bili_danmaku_utils.py
@@ -35,6 +35,8 @@ class BiliDmErrorCode(Enum):
     # 自定义错误码
     NETWORK_ERROR = (-9999, "发送弹幕时发生网络或请求异常。请检查您的网络连接。", True)
     UNKNOWN_ERROR = (-9998, "发送弹幕时发生未知异常，请联系开发者或稍后再试。", True)
+    TIMEOUT_ERROR = (-9997, "发送弹幕请求超时，请检查网络或稍后再试。", True)
+    CONNECTION_ERROR = (-9996, "发送弹幕时网络连接异常，请检查网络或稍后再试。", True)
     GENERIC_FAILURE = (-1, "操作失败，详见原始消息或尝试稍后再试。", False)  # 当B站返回code是-1或未识别的code时使用
 
     @property
@@ -62,10 +64,14 @@ class BiliDmErrorCode(Enum):
         """根据B站返回的code和原始信息，解析出最终的code和用于显示的友好消息"""
         # 尝试从枚举中获取友好提示
         enum_member = BiliDmErrorCode.from_code(code)
-        display_msg = enum_member.description_str if enum_member else raw_message
+        if enum_member:
+            display_msg = enum_member.description_str
+        else:
+            # 如果没有匹配的枚举成员，且B站返回的原始消息不为空，则使用原始消息，否则使用通用失败消息
+            display_msg = raw_message if raw_message and raw_message != "无B站原始消息" else BiliDmErrorCode.GENERIC_FAILURE.description_str
 
         # 如果 B站原始消息为空且 code 不是成功，并且枚举也未提供描述，则使用通用提示
-        if not display_msg and code != BiliDmErrorCode.SUCCESS.value:
+        if not display_msg and code != BiliDmErrorCode.SUCCESS.code:
             display_msg = BiliDmErrorCode.UNKNOWN_ERROR.description_str
             
         return code, display_msg

--- a/gui.py
+++ b/gui.py
@@ -11,7 +11,7 @@ from config_manager import load_config, save_config
 class Application(ttk.Window):
     def __init__(self):
         super().__init__(themename="litera")
-        self.title("B站弹幕补档工具 v0.6.0")
+        self.title("B站弹幕补档工具 v0.6.3")
         self.geometry("750x700")
 
         self.stop_event = threading.Event()


### PR DESCRIPTION
本次提交为弹幕发送过程引入了全面的错误处理与报告系统。此前错误管理方式零散且缺乏明确性。本次重构通过集中化错误定义和结构化发送结果来解决这些问题。

主要变更包括：

1.  **在`bili_danmaku_utils.py`中创建`BiliDmErrorCode`枚举：**
    *   集中所有已知B站API错误码和自定义内部错误码（如NETWORK_ERROR）
    *   每个错误码都配有用户友好的描述说明
    *   提供便捷查询的`from_code`类方法

2.  **引入`DanmakuSendResult`类：**
    *   封装每次弹幕发送尝试的结果
    *   包含状态（成功/失败）、错误码、原始API消息和面向用户的友好提示信息
    *   提供清晰的`__str__`表示用于日志记录

3.  **重构`main.py`中的`BiliDanmakuSender`：**
    *   `_send_single_danmaku`现在返回包含详细失败信息的`DanmakuSendResult`对象而非简单布尔值
    *   改进`send_danmaku_from_xml`中的主发送循环以解析`DanmakuSendResult`
    *   实现区分致命错误（如认证失败、网络问题）和非致命错误（如内容违禁）的逻辑：前者终止整个任务，后者仅跳过当前弹幕
    *   增强日志信息量，显示错误码和详细消息

此次彻底改造通过使错误状态显式化和可管理，显著提升了应用的可靠性、可维护性和用户体验

## Sourcery 总结

通过集中错误代码、结构化发送结果并优化主发送循环，实现弹幕发送的全面错误处理和报告系统。

新功能：
- 添加 `BiliDmErrorCode` 枚举，用于整合 API 和自定义错误代码，并提供用户友好的描述和查找功能。
- 引入 `DanmakuSendResult` 类，用于封装发送尝试，包含状态、错误代码、原始消息和显示消息。
- 重构 `_send_single_danmaku`，使其返回 `DanmakuSendResult` 而不是布尔值。
- 更新 `send_danmaku_from_xml`，以解释结果代码，在致命错误时中止，并跳过非致命错误。

改进：
- 增强 `get_video_info`，增加结构化错误代码映射和网络异常处理。
- 改进日志输出，在解析和发送过程中增加图标和上下文详细信息。
- 将 GUI 应用程序版本从 v0.5.1 提升到 v0.6.0。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过集中管理错误码、返回结构化的发送结果，并优化发送循环，以一致地处理和报告致命及非致命错误，从而实现一个健壮的弹幕发送错误处理和报告框架。

新功能：
- 添加 BiliDmErrorCode 枚举，用于集中管理 Bilibili API 和自定义错误码，并包含描述和致命错误标志。
- 引入 DanmakuSendResult 类，用于封装每条消息的发送状态、错误码和面向用户的消息。
- 重构 _send_single_danmaku 方法，以返回结构化的 DanmakuSendResult 并处理 API 和网络错误。
- 增强 send_danmaku_from_xml 方法，以评估 DanmakuSendResult，区分致命和非致命错误，并据此跳过或中止，最后总结结果。

改进：
- 改进 get_video_info 方法，通过结构化的错误码解析和网络异常处理。
- 在解析和发送过程中增强日志记录，使用表情符号和详细上下文。
- 将 GUI 应用程序版本从 v0.5.1 提升至 v0.6.0。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过集中错误定义、将发送结果封装到专用类中，并重构核心发送和解析逻辑以使用结构化错误和详细日志记录，实现了一个健壮的弹幕发送错误处理框架。

新功能：
- 添加 `BiliDmErrorCode` 枚举，用于集中管理 Bilibili API 和自定义错误码，包含描述和致命错误标志。
- 引入 `DanmakuSendResult` 类，封装单个发送尝试，包括状态、错误码和面向用户的消息。

改进：
- 重构 `get_video_info`，将 API 失败映射到结构化错误码并处理网络异常。
- 更新 `_send_single_danmaku` 以返回 `DanmakuSendResult`，解析 API 响应，处理限流、网络错误和未知异常。
- 修改 `send_danmaku_from_xml` 以处理 `DanmakuSendResult` 对象，区分致命和非致命错误，跟踪尝试次数，并记录详细摘要。
- 增强 XML 解析和日志记录，使用表情符号和更具上下文的消息。

杂项：
- 将 GUI 应用程序版本从 v0.5.1 提升到 v0.6.0。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过集中错误码、封装发送结果、重构发送循环以区分致命和非致命错误，并增强日志记录和总结，实现一个健壮的弹幕发送错误处理框架。

新功能：
- 添加 BiliDmErrorCode 枚举，用于集中管理 Bilibili API 和自定义错误码，包含描述和致命错误标志
- 引入 DanmakuSendResult 类，用于封装每次弹幕发送尝试，包含状态、原始和显示消息
- 重构 _send_single_danmaku 方法，使其返回 DanmakuSendResult 并处理特定异常（超时、连接、网络）
- 增强 send_danmaku_from_xml 方法，以处理 DanmakuSendResult，区分致命/非致命错误，管理延迟，并总结结果

改进：
- 改进 get_video_info 方法，以将 API 失败映射到结构化错误码并处理网络异常
- 增强发送和解析过程中的日志记录，加入表情符号和详细上下文
- 将延迟处理和总结日志记录提取到独立的私有方法中
- 将 GUI 应用程序版本从 v0.5.1 升级到 v0.6.3

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a robust error handling framework for danmaku sending by centralizing error codes, encapsulating send results, refactoring the send loop to differentiate fatal and non-fatal errors, and enhancing logging and summaries.

New Features:
- Add BiliDmErrorCode enum to centralize Bilibili API and custom error codes with descriptions and fatal flags
- Introduce DanmakuSendResult class to encapsulate each danmaku send attempt with status, raw and display messages
- Refactor _send_single_danmaku to return DanmakuSendResult and handle specific exceptions (timeout, connection, network)
- Enhance send_danmaku_from_xml to process DanmakuSendResult, distinguish fatal/non-fatal errors, manage delays, and summarize results

Enhancements:
- Improve get_video_info to map API failures to structured error codes and handle network exceptions
- Enhance logging throughout the send and parse processes with emojis and detailed context
- Extract delay handling and summary logging into dedicated private methods
- Bump GUI application version from v0.5.1 to v0.6.3

</details>

</details>

</details>

</details>