### PR TITLE
enhance: 改进弹幕ID生成机制以增强鲁棒性

### DIFF
--- a/bili_danmaku_utils.py
+++ b/bili_danmaku_utils.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import xml.etree.ElementTree as ET
 import logging
+import uuid
 
 
 logger = logging.getLogger("BiliUtils")
@@ -146,7 +147,7 @@ class DanmakuParser:
                         if len(p_attr) > 7:
                             danmaku['id'] = p_attr[7]  # 在线弹幕的唯一ID
                         else:
-                            danmaku['id'] = f"{progress}_{msg}_{hash(xml_content) % 10000}"  # 生成一个伪ID
+                            danmaku['id'] = str(uuid.uuid4())  # 生成一个伪ID
                     else:
                         if len(p_attr) >= 4:
                             danmaku['mode'] = int(p_attr[1])


### PR DESCRIPTION
在`bili_danmaku_utils.py`中将不可靠的基于哈希的备用ID生成方式替换为UUIDv4。
此项变更在上游B站ID不可用时有效降低潜在ID冲突风险，确保每条弹幕的唯一标识性。

## Sourcery 总结

改进：
- 使用 `uuid.uuid4()` 而非基于哈希的方法来生成备用弹幕 ID，以最大程度地降低冲突风险。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Use uuid.uuid4() for generating fallback danmaku IDs instead of a hash-based method to minimize collision risk.

</details>