### PR TITLE
feat: 调整相关UI组件以禁用焦点

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -43,7 +43,7 @@ class GuiLoggingHandler(logging.Handler):
 class Application(ttk.Window):
     def __init__(self):
         super().__init__(themename="litera")
-        self.title("B站弹幕发射器 v0.9.2")
+        self.title("B站弹幕发射器 v0.9.4")
         self.geometry("780x750")
         # --- 模型、控制器、视图的装配 ---
         self.shared_data = SharedDataModel()
@@ -186,7 +186,7 @@ class Application(ttk.Window):
         frame.pack(fill=BOTH, expand=True)
 
         ttk.Label(frame, text="B站弹幕补档工具", font=("TkDefaultFont", 14, "bold")).pack(pady=(0, 10))
-        ttk.Label(frame, text="版本: 0.9.2").pack(pady=5)
+        ttk.Label(frame, text="版本: 0.9.4").pack(pady=5)
         ttk.Label(frame, text="作者: Miku_oso").pack(pady=5)
 
         # 让窗口大小自适应内容

--- a/monitor_tab.py
+++ b/monitor_tab.py
@@ -117,7 +117,8 @@ class MonitorTab(ttk.Frame):
             text="开始监视", 
             command=self.toggle_monitoring,
             style="success.TButton", 
-            width=12
+            width=12,
+            takefocus=0
         )
         self.start_button.grid(row=0, column=2, sticky="e")
 

--- a/sender_tab.py
+++ b/sender_tab.py
@@ -38,11 +38,11 @@ class SenderTab(ttk.Frame):
         auth_frame.columnconfigure(1, weight=1)
 
         ttk.Label(auth_frame, text="SESSDATA:").grid(row=0, column=0, sticky="w", padx=5, pady=8)
-        self.sessdata_entry = ttk.Entry(auth_frame, show="*", textvariable=self.model.sessdata)
+        self.sessdata_entry = ttk.Entry(auth_frame, show="*", textvariable=self.model.sessdata, takefocus=0)
         self.sessdata_entry.grid(row=0, column=1, sticky="ew")
 
         ttk.Label(auth_frame, text="BILI_JCT:").grid(row=1, column=0, sticky="w",padx=5, pady=8)
-        self.bili_jct_entry = ttk.Entry(auth_frame, show="*", textvariable=self.model.bili_jct)
+        self.bili_jct_entry = ttk.Entry(auth_frame, show="*", textvariable=self.model.bili_jct, takefocus=0)
         self.bili_jct_entry.grid(row=1, column=1, sticky="ew")
 
         # --- 设置区 ---
@@ -51,13 +51,13 @@ class SenderTab(ttk.Frame):
         settings_frame.columnconfigure(1, weight=1)
 
         ttk.Label(settings_frame, text="BV号:").grid(row=0, column=0, sticky="w", padx=5, pady=8)
-        self.bvid_entry = ttk.Entry(settings_frame, textvariable=self.model.bvid)
+        self.bvid_entry = ttk.Entry(settings_frame, textvariable=self.model.bvid, takefocus=0)
         self.bvid_entry.grid(row=0, column=1, sticky="ew") 
         self.get_parts_button = ttk.Button(settings_frame, text="获取分P", command=self.fetch_video_parts)
         self.get_parts_button.grid(row=0, column=2, padx=(5, 0))
 
         ttk.Label(settings_frame, text="选择分P:").grid(row=1, column=0, sticky="w", padx=5, pady=8)
-        self.part_combobox = ttk.Combobox(settings_frame, textvariable=self.model.part_var, state="readonly", bootstyle="secondary")
+        self.part_combobox = ttk.Combobox(settings_frame, textvariable=self.model.part_var, state="readonly", bootstyle="secondary", takefocus=0)
         self.part_combobox.grid(row=1, column=1, columnspan=2, sticky="ew", padx=(0, 5))
         self.part_combobox.bind("<<ComboboxSelected>>", lambda _: (self.focus(), self.part_combobox.selection_clear(), self._on_part_selected()))
         self.part_combobox.set("请先获取分P")
@@ -66,7 +66,7 @@ class SenderTab(ttk.Frame):
         ttk.Label(settings_frame, text="弹幕文件:").grid(row=2, column=0, sticky="w", padx=5, pady=8)
         self.file_path_label = ttk.Label(settings_frame, text="请选择弹幕XML文件...", style="secondary.TLabel")
         self.file_path_label.grid(row=2, column=1, sticky="ew", padx=(0, 5))
-        self.select_button = ttk.Button(settings_frame, text="选择文件", command=self.select_file, style="info.TButton")
+        self.select_button = ttk.Button(settings_frame, text="选择文件", command=self.select_file, style="info.TButton", takefocus=0)
         self.select_button.grid(row=2, column=2, sticky="e")
         self.file_path_tooltip = ToolTip(self.file_path_label, text="") 
         
@@ -76,11 +76,11 @@ class SenderTab(ttk.Frame):
         advanced_frame.columnconfigure(1, weight=1); advanced_frame.columnconfigure(3, weight=1)
 
         ttk.Label(advanced_frame, text="最小延迟(秒):").grid(row=0, column=0, sticky="w", padx=5, pady=5)
-        self.min_delay_entry = ttk.Entry(advanced_frame, width=10, textvariable=self.model.min_delay)
+        self.min_delay_entry = ttk.Entry(advanced_frame, width=10, textvariable=self.model.min_delay, takefocus=0)
         self.min_delay_entry.grid(row=0, column=1)
 
         ttk.Label(advanced_frame, text="最大延迟(秒):").grid(row=0, column=2, sticky="w", padx=(20, 5), pady=5)
-        self.max_delay_entry = ttk.Entry(advanced_frame, width=10, textvariable=self.model.max_delay)
+        self.max_delay_entry = ttk.Entry(advanced_frame, width=10, textvariable=self.model.max_delay, takefocus=0)
         self.max_delay_entry.grid(row=0, column=3)
         
         # --- 日志输出区 ---
@@ -96,7 +96,7 @@ class SenderTab(ttk.Frame):
         action_frame.columnconfigure(0, weight=1)
         self.progress_bar = ttk.Progressbar(action_frame, mode='determinate', style='success.Striped.TProgressbar')
         self.progress_bar.grid(row=0, column=0, sticky="ew", padx=(0, 10))
-        self.start_button = ttk.Button(action_frame, text="开始任务", command=self.start_task, style="success.TButton", width=12)
+        self.start_button = ttk.Button(action_frame, text="开始任务", command=self.start_task, style="success.TButton", width=12, takefocus=0)
         self.start_button.grid(row=0, column=1)
 
     def select_file(self):


### PR DESCRIPTION
调整UI组件以禁用焦点，并将应用程序版本更新至0.9.4。

## Sourcery 总结

禁用各种 UI 组件的键盘焦点以简化用户界面，并将应用程序版本提升到 0.9.4

改进：
- 将 sender_tab 和 monitor_tab 中 Entry、Button 和 Combobox 控件的 takefocus 设置为 0，以防止不必要的焦点
- 更新多个选项卡中的 UI 组件以禁用焦点导航

杂项：
- 将应用程序标题和“关于”对话框版本从 0.9.2 更新到 0.9.4

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable keyboard focus on various UI components to streamline the user interface and bump the application version to 0.9.4

Enhancements:
- Set takefocus=0 on Entry, Button, and Combobox widgets in sender_tab and monitor_tab to prevent unwanted focus
- Update UI components across multiple tabs to disable focus navigation

Chores:
- Update application title and About dialog version from 0.9.2 to 0.9.4

</details>