### PR TITLE
fix: 更正 Github 仓库 URL

### DIFF
--- a/help_content.py
+++ b/help_content.py
@@ -80,5 +80,5 @@ ABOUT_TEXT_ISSUE_LINK_LABEL = ">>> 前往 Issue 页面 <<<"
 
 
 # --- URL常量 ---
-GITHUB_REPO_URL = "https://github.com/TouhouGleaners/BiliDanmakuSender"
+GITHUB_REPO_URL = "https://github.com/TouhouGleaners/danmaku-sender"
 GITHUB_ISSUES_URL = f"{GITHUB_REPO_URL}/issues"


### PR DESCRIPTION
## Sourcery 总结

Bug 修复:
- 更新 GITHUB_REPO_URL 以使用正确的 danmaku-sender 仓库路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update GITHUB_REPO_URL to use the correct danmaku-sender repository path

</details>