### PR TITLE
fix(wbi_signer): 防止 WBI 签名过程修改原始弹幕内容

### DIFF
--- a/wbi_signer.py
+++ b/wbi_signer.py
@@ -30,17 +30,23 @@ class WbiSigner:
         """为请求参数进行 wbi 签名"""
         mixin_key = WbiSigner.get_mixin_key(img_key + sub_key)
         curr_time = round(time.time())
-        params['wts'] = curr_time                                   # 添加 wts 字段
-        params = dict(sorted(params.items()))                       # 按照 key 重排参数
+
+        params_for_sign = params.copy()
+        params_for_sign['wts'] = curr_time                       # 添加 wts 字段
+        params_for_sign = dict(sorted(params_for_sign.items()))  # 按照 key 重排参数
         # 过滤 value 中的 "!'()*" 字符
-        params = {
+        params_for_sign_filtered = {
             k : ''.join(filter(lambda chr: chr not in "!'()*", str(v)))
             for k, v 
-            in params.items()
+            in params_for_sign.items()
         }
-        query = urllib.parse.urlencode(params)                      # 序列化参数
+
+        query = urllib.parse.urlencode(params_for_sign_filtered)    # 序列化参数
         wbi_sign = md5((query + mixin_key).encode()).hexdigest()    # 计算 w_rid
+
         params['w_rid'] = wbi_sign
+        params['wts'] = curr_time
+
         return params
 
     @classmethod


### PR DESCRIPTION
WBI 签名的 `sign_params` 函数会过滤掉参数中的 \"!'()*\" 等特殊字符，
这是一个符合算法要求的正确行为。
然而，之前的实现直接在原始的 `params` 字典上进行操作，导致了一个
严重的副作用：原始的弹幕内容（danmaku_text）如果包含这些特殊
字符（如颜文字），其内容会被永久性地修改。
例如，弹幕 `( ´ ▽ ` )ﾉ` 会被错误地变成 ` ´ ▽ ` ﾉ` 后再发送。

此修复通过在 `sign` 方法内部对 `params` 字典进行一次浅拷贝
(`.copy()`)，确保签名过程中的所有修改都发生在一个隔离的
副本上，从而保证了原始弹幕数据的完整性和正确性。

## Sourcery 总结

错误修复:
- 防止在 WBI 签名过程中原始参数字典的变动，以保留弹幕文本中的特殊字符

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent original params dict mutation during WBI signing to preserve special characters in danmaku text

</details>