### PR TITLE
[被改写历史]fix(build): 确保打包EXE后可正确显示程序元数据

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pyinstaller
+        pip install .
     - name: Build with Pyinstaller
       run: |
         $ttkbootstrap_path = (Get-Command pip).path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"


### PR DESCRIPTION
- 在 GitHub Actions 的 PyInstaller 构建步骤前，新增 `pip install .` 命令。
- 此更改确保项目作为本地包安装到构建环境中，生成必要的 `.dist-info` 元数据目录。
- 解决 `importlib.metadata` 无法在打包后的独立可执行文件中获取程序版本和作者信息的问题。
- 优化了打包流程，使得 `BiliDanmakuSender` 的 `help` 界面能正确展示动态获取的版本信息。

## Sourcery 总结

在打包前本地安装项目，以包含元数据并使版本和作者信息能够在独立可执行文件中正确检索

Bug 修复:
- 确保 .dist-info 元数据存在于打包后的 EXE 中，以便 importlib.metadata 可以获取程序版本和作者
- 修复 BiliDanmakuSender 帮助界面，以显示动态检索到的版本信息

CI:
- 在 GitHub Actions 中，于 PyInstaller 构建前添加 “pip install .” 步骤

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Install the project locally before packaging to include metadata and enable correct retrieval of version and author in the standalone executable

Bug Fixes:
- Ensure .dist-info metadata is present in the packaged EXE so importlib.metadata can fetch program version and author
- Fix BiliDanmakuSender help interface to display the dynamically retrieved version information

CI:
- Add “pip install .” step before PyInstaller build in GitHub Actions

</details>