### PR TITLE
[被改写历史]chore: 修改PyInstaller构建的自动化发布流程

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [created]
 jobs:
-   build:
+  build:
     runs-on: windows-latest
     permissions:
       contents: write
@@ -14,20 +14,31 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-    - name: Install dependencies
+
+    - name: Install dependencies and toml parser (using tomllib, no extra install needed)
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pyinstaller
+      shell: pwsh
+      
+    - name: Get version from pyproject.toml
+      id: get_version
+      run: |
+        $version = (python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+        echo "APP_VERSION=$version" >> $GITHUB_ENV
+      shell: pwsh
+
     - name: Build with Pyinstaller
       run: |
-        $ttkbootstrap_path = (Get-Command pip).path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"
-        pyinstaller --noconfirm --onefile --windowed --name "BiliDanmakuSender" `
+        pyinstaller --noconfirm --onefile --windowed --name "BiliDanmakuSender-${{ env.APP_VERSION }}" `
           --icon="assets/icon.ico" `
-          --add-data "$ttkbootstrap_path;ttkbootstrap" `
           main_app.py
+      shell: pwsh
+
     - name: Debug - List contents of dist directory
       run: Get-ChildItem -Path ./dist
+      shell: pwsh
 
     - name: Upload EXE artifact
       uses: actions/upload-release-asset@v1
@@ -35,7 +46,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }} 
-        asset_name: BiliDanmakuSender-${{ github.ref_name }}.exe
-        asset_path: ./dist/BiliDanmakuSender.exe
+        asset_name: BiliDanmakuSender-${{ env.APP_VERSION }}.exe
+        asset_path: ./dist/BiliDanmakuSender-${{ env.APP_VERSION }}.exe
         asset_content_type: application/vnd.microsoft.portable-executable
-


### PR DESCRIPTION
## Sourcery 总结

增强 Windows 构建工作流，使其能够自动提取包版本并将其包含在 PyInstaller 工件名称中，统一 PowerShell 下的步骤，并相应地更新发布资产上传。

增强功能：
- 在运行时使用 Python 的 tomllib 从 pyproject.toml 中提取版本并设置为 APP_VERSION
- 将 APP_VERSION 包含在 PyInstaller 输出名称和发布资产文件名中

构建：
- 在一个步骤中安装依赖项和 PyInstaller
- 更新 upload-release-asset action 以使用动态派生的 APP_VERSION

CI：
- 将关键工作流步骤切换到 PowerShell 上下文
- 添加一个调试步骤以在上传前列出 dist 目录的内容

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the Windows build workflow to automatically extract the package version and include it in the PyInstaller artifact name, standardize steps under PowerShell, and update the release asset upload accordingly.

Enhancements:
- Extract version from pyproject.toml at runtime using Python’s tomllib and set as APP_VERSION
- Include APP_VERSION in the PyInstaller output name and release asset filename

Build:
- Install dependencies and PyInstaller in one step
- Update upload-release-asset action to use the dynamically derived APP_VERSION

CI:
- Switch key workflow steps to PowerShell context
- Add a debug step to list the contents of the dist directory before upload

</details>