### PR TITLE
fix(network): 为所有HTTP请求添加超时以防止程序挂起

### DIFF
--- a/bili_sender.py
+++ b/bili_sender.py
@@ -46,7 +46,7 @@ class BiliDanmakuSender:
         url = "https://api.bilibili.com/x/web-interface/view"
         params = {'bvid': self.bvid}
         try:
-            response = self.session.get(url, params=params)
+            response = self.session.get(url, params=params, timeout=10)
             response.raise_for_status()
             data = response.json()
 
@@ -77,6 +77,9 @@ class BiliDanmakuSender:
                 _, display_message = BiliDmErrorCode.resolve_bili_error(error_code, raw_message)
                 self.logger.error(f"错误: 获取视频信息失败, Code: {error_code}, 信息: {display_message} (原始: {raw_message})")
                 raise RuntimeError(f"错误: 获取视频信息失败, Code: {error_code}, 信息: {display_message} (原始: {raw_message})")
+        except Timeout as e:
+            self.logger.error(f"错误: 请求视频信息时发生超时异常: {e}", exc_info=True)
+            raise RuntimeError(f"错误: 请求视频信息时发生超时异常: {e}") from e
         except RequestException as req_e:
             self.logger.error(f"错误: 请求视频信息时发生网络异常: {req_e}", exc_info=True)
             raise RuntimeError(f"错误: 请求视频信息时发生网络异常: {req_e}") from req_e
@@ -121,7 +124,7 @@ class BiliDanmakuSender:
         signed_params = WbiSigner.enc_wbi(params=base_params, img_key=img_key, sub_key=sub_key)
 
         try:
-            response = self.session.post(url, data=signed_params)
+            response = self.session.post(url, data=signed_params, timeout=10)
             response.raise_for_status()
             result_json = response.json()
 

--- a/help_content.py
+++ b/help_content.py
@@ -1,5 +1,5 @@
 # --- 版本常量 ---
-APP_VERSION = "1.0.0-rc.1"
+APP_VERSION = "1.0.0-rc.2"
 
 # --- 窗口标题常量 ---
 MAIN_WINDOW_TITLE_PREFIX = "B站弹幕补档工具"

--- a/wbi_signer.py
+++ b/wbi_signer.py
@@ -64,16 +64,20 @@ class WbiSigner:
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36 Edg/139.0.0.0',
             'Referer': 'https://www.bilibili.com/'
         }
-        resp = requests.get('https://api.bilibili.com/x/web-interface/nav', headers=headers)
-        resp.raise_for_status()
-        json_content = resp.json()
-        img_url: str = json_content['data']['wbi_img']['img_url']
-        sub_url: str = json_content['data']['wbi_img']['sub_url']
-        img_key = img_url.rsplit('/', 1)[1].split('.')[0]
-        sub_key = sub_url.rsplit('/', 1)[1].split('.')[0]
+        try:
+            resp = requests.get('https://api.bilibili.com/x/web-interface/nav', headers=headers, timeout=10)
+            resp.raise_for_status()
+            json_content = resp.json()
+            img_url: str = json_content['data']['wbi_img']['img_url']
+            sub_url: str = json_content['data']['wbi_img']['sub_url']
+            img_key = img_url.rsplit('/', 1)[1].split('.')[0]
+            sub_key = sub_url.rsplit('/', 1)[1].split('.')[0]
 
-        # 更新缓存
-        cls._cached_keys = (img_key, sub_key)
-        cls._cached_time = current_time
-        
-        return cls._cached_keys
+            # 更新缓存
+            cls._cached_keys = (img_key, sub_key)
+            cls._cached_time = current_time
+            
+            return cls._cached_keys
+        except (requests.RequestException, ValueError) as e:
+            print(f"FATAL: Failed to get WBI keys: {e}")
+            raise RuntimeError(f"获取B站签名密钥失败，请检查网络连接或稍后再试。错误: {e}") from e


### PR DESCRIPTION
先前版本在网络状况不佳时（如连接缓慢、DNS解析失败）会因缺少请求超时设置而导致程序无限期卡死，严重影响用户体验。

本次修改通过为所有使用 `requests` 库发出的外部HTTP请求统一设置了合理的超时参数

主要变更点：
- 在 `bili_sender.py` 中，为获取视频信息、发送弹幕和获取在线弹幕列表的请求添加了 `timeout`。
- 在 `wbi_signer.py` 中，为获取WBI签名密钥的请求添加了 `timeout` 并增强了异常处理。

此举不仅防止了程序挂起，还激活了先前已定义但未被有效触发的 `TIMEOUT_ERROR` 错误处理逻辑，使网络超时能够被正确捕获、记录并报告给用户，显著提升了程序的健壮性。

## Sourcery 摘要

为所有外部 HTTP 请求添加 10 秒超时，以防止无限期阻塞，改进超时及其他请求失败的错误处理，并提升应用程序版本。

错误修复:
- 通过对所有 HTTP 请求设置超时来防止程序挂起。

功能增强:
- 在 WBI 密钥检索中添加超时和异常处理，以激活现有的超时错误逻辑。
- 在获取视频信息和发送弹幕消息时，记录并抛出超时错误。

日常维护:
- 将 APP_VERSION 从 1.0.0-rc.1 提升到 1.0.0-rc.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add 10-second timeouts to all external HTTP requests to prevent indefinite blocking, improve error handling for timeout and other request failures, and bump the application version.

Bug Fixes:
- Prevent program hangs by setting a timeout on all HTTP requests.

Enhancements:
- Add timeout and exception handling to WBI key retrieval to activate existing timeout error logic.
- Log and raise on timeout errors when fetching video info and sending danmaku messages.

Chores:
- Bump APP_VERSION from 1.0.0-rc.1 to 1.0.0-rc.2.

</details>