### PR TITLE
feat: Auto-select part if only one exists and prompt for multi-parts

### DIFF
--- a/sender_tab.py
+++ b/sender_tab.py
@@ -193,11 +193,17 @@ class SenderTab(ttk.Frame):
             def _update_ui_success():
                 # 这是一个在主线程中更新UI的回调函数
                 if display_parts:
-                    self.logger.info(f"✅ 成功获取到 {len(display_parts)} 个分P，已为您选中第一个")
                     self.part_combobox['values'] = display_parts
-                    self.model.part_var.set(display_parts[0])  # 默认选中第一个
                     self.part_combobox.config(state="readonly")
-                    self._on_part_selected()
+
+                    if len(display_parts) == 1:
+                        self.logger.info(f"✅ 成功获取到 1 个分P，已为您自动选中。")
+                        self.model.part_var.set(display_parts[0])
+                    else:
+                        self.logger.info(f"✅ 成功获取到 {len(display_parts)} 个分P，请手动选择。")
+                        self.model.part_var.set("请在下拉框中选择一个分P")
+
+                    self._on_part_selected()  # 自动选择或提示后，都触发一次更新逻辑
                 else:
                     self.part_combobox['values'] = []
                     self.model.part_var.set("未找到任何分P")


### PR DESCRIPTION
## Sourcery 总结

调整 sender_tab 中的部件选择逻辑：当只有一个部件可用时自动选择该部件，当检索到多个部件时提示用户进行选择。

增强功能：
- 检索时自动选择单个可用部件
- 当获取到多个部件时，显示占位符并记录日志提示，以便手动选择

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust part selection logic in sender_tab: auto-select the part when only one is available and prompt the user to choose when multiple parts are retrieved.

Enhancements:
- Auto-select the single available part upon retrieval
- Display a placeholder and log prompt for manual selection when multiple parts are fetched

</details>