### PR TITLE
refactor: 重构并中心化应用的日志系统

### DIFF
--- a/bili_monitor.py
+++ b/bili_monitor.py
@@ -28,7 +28,7 @@ class BiliDanmakuMonitor:
         self.interval = interval
         self.time_tolerance = time_tolerance
         self.danmaku_parser = DanmakuParser()
-        self.logger = logging.getLogger("monitor_tab")
+        self.logger = logging.getLogger("MonitorTab")
         
         # 确保 local_danmakus 始终是一个列表
         self.local_danmakus = local_danmakus_list if local_danmakus_list is not None else []  

--- a/bili_sender.py
+++ b/bili_sender.py
@@ -21,12 +21,6 @@ class BiliDanmakuSender:
         self.session = self._create_session(sessdata, bili_jct)
         self.danmaku_parser = DanmakuParser()
         self.logger = logging.getLogger("DanmakuSender")
-        if not self.logger.handlers:
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-            handler.setFormatter(formatter)
-            self.logger.addHandler(handler)
-            self.logger.setLevel(logging.INFO)
         self.wbi_keys = WbiSigner.get_wbi_keys()
 
     def _create_session(self, sessdata: str, bili_jct: str) -> requests.Session:

--- a/log_utils.py
+++ b/log_utils.py
@@ -1,0 +1,31 @@
+import logging
+
+
+class GuiLoggingHandler(logging.Handler):
+    """
+    一个自定义的日志处理程序，将日志消息根据其来源路由到不同的GUI文本框。
+    它通过检查日志记录的名称(record.name)来决定目标。
+    """
+    def __init__(self):
+        super().__init__()
+        # 存储不同日志目标的更新函数
+        self.output_targets = {
+            "sender_tab": None,
+            "monitor_tab": None,
+        }
+
+    def emit(self, record):
+        """根据 record.name 将日志消息发送到正确的GUI组件。"""
+        msg = self.format(record)
+
+        target_func = None
+
+        if record.name in ("SenderTab", "ValidatorTab", "DanmakuSender", "DanmakuParser", "BiliUtils"):
+            target_func = self.output_targets.get("sender_tab")
+        elif record.name == "MonitorTab":
+            target_func = self.output_targets.get("monitor_tab")
+
+        if not target_func:
+            target_func = self.output_targets.get("sender_tab")
+        if target_func:
+            target_func(msg)

--- a/monitor_tab.py
+++ b/monitor_tab.py
@@ -25,7 +25,7 @@ class MonitorTab(ttk.Frame):
         super().__init__(parent, padding=15)
         self.model = model
         self.app = app
-        self.logger = logging.getLogger("monitor_tab")
+        self.logger = logging.getLogger("MonitorTab")
         # 配置主Frame的列和行权重
         self.columnconfigure(0, weight=1)
         self.rowconfigure(2, weight=1)

--- a/sender_tab.py
+++ b/sender_tab.py
@@ -22,7 +22,7 @@ class SenderTab(ttk.Frame):
         super().__init__(parent, padding=15)
         self.model = model
         self.app = app  # 主应用实例，用于after调用
-        self.logger = logging.getLogger("sender_tab")
+        self.logger = logging.getLogger("SenderTab")
         self.columnconfigure(0, weight=1)
         self.rowconfigure(3, weight=1)
         self.stop_event = threading.Event()


### PR DESCRIPTION
对应用的日志系统进行了结构性重构，以实现单一配置源和更清晰的模块职责。
主要变更：
- 将 GuiLoggingHandler 提取到独立的 log_utils.py 文件中，使其成为一个独立的工具模块。
- 清理了业务模块 (如 bili_sender.py) 中所有分散的、局部的日志配置代码。

## Sourcery 总结

通过提取 GUI 日志处理器、统一日志记录器配置以及移除分散的每个模块设置，集中并重构了应用程序的日志系统。

改进：
- 将 `GuiLoggingHandler` 提取到一个独立的 `log_utils.py` 模块中，并在 `main_app.py` 中导入
- 在 `main_app` 中整合所有日志记录器设置，并使用包含日志记录器名称的统一格式化器
- 标准化跨模块的日志记录器名称（`SenderTab`, `MonitorTab`, `ValidatorTab`, `DanmakuSender`, `DanmakuParser`, `BiliUtils`），并移除本地处理器设置
- 增强 `GuiLoggingHandler` 的路由逻辑，以将模块日志导向正确的 GUI 组件，并提供回退机制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and refactor the application's logging system by extracting the GUI logging handler, unifying logger configuration, and removing scattered per-module setups.

Enhancements:
- Extract GuiLoggingHandler into a standalone log_utils.py module and import it in main_app.py
- Consolidate all logger setup in main_app with a unified formatter that includes logger names
- Standardize logger names across modules (SenderTab, MonitorTab, ValidatorTab, DanmakuSender, DanmakuParser, BiliUtils) and remove local handler setups
- Enhance GuiLoggingHandler routing logic to direct module logs to the correct GUI components with a fallback

</details>