### PR TITLE
feat: 添加弹幕发送进度回调功能并优化UI状态更新

### DIFF
--- a/shared_data.py
+++ b/shared_data.py
@@ -30,10 +30,11 @@ class SharedDataModel:
         # --- 高级设置 (仅MonitorTab使用) ---
         self.monitor_interval = ttk.StringVar(value="60")  # 刷新间隔，默认60秒
         self.time_tolerance = ttk.StringVar(value="500")  # 时间容差，默认500毫秒
-        self.monitor_progress_var = ttk.DoubleVar(value=0.0)
         self.loaded_danmakus = []  # 解析后的本地弹幕列表
 
         # --- 状态信息 (用于状态栏显示) ---
         # 这些变量将由后台任务更新，并由状态栏显示
         self.sender_status_text = ttk.StringVar(value="发送器：待命")
+        self.sender_progress_var = ttk.DoubleVar(value=0.0)
         self.monitor_status_text = ttk.StringVar(value="监视器：待命")
+        self.monitor_progress_var = ttk.DoubleVar(value=0.0)


### PR DESCRIPTION
## Sourcery 总结

为弹幕发送器添加实时进度报告支持，并优化发送器选项卡的用户界面以显示进度和状态更新

新功能:
- 在 `send_danmaku_from_list` 中支持 `progress_callback`，以报告已尝试发送的数量与总发送数量
- 从后台线程通过模型绑定变量更新用户界面进度条
- 在任务执行期间，在操作区域显示发送器状态文本

改进:
- 重新配置发送器选项卡布局：调整填充、列权重、移动按钮并添加状态标签
- 在任务开始和完成时初始化并重置进度和状态变量
- 将 `sender_progress_var` 添加到共享数据模型中，用于绑定进度更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add real-time progress reporting support to the danmaku sender and optimize the sender tab UI to display progress and status updates

New Features:
- Support a progress_callback in send_danmaku_from_list to report attempted vs total sends
- Update the UI progress bar via a model-bound variable from the background thread
- Display sender status text in the action area during task execution

Enhancements:
- Reconfigure sender tab layout: adjust padding, column weights, move buttons, and add a status label
- Initialize and reset progress and status variables at task start and completion
- Add sender_progress_var to the shared data model for binding progress updates

</details>