### PR TITLE
feat: 新增确认发送弹幕的弹窗提示功能

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -3,7 +3,7 @@ class AppInfo:
     NAME = "B站弹幕补档工具"
     NAME_EN = "BiliDanmakuSender"
     AUTHOR = "Miku_oso"
-    VERSION = "1.1.0"
+    VERSION = "1.1.0-beta.1"
     LOG_FILE_NAME = "latest.log"
     LOG_DIR_NAME = "logs"
     

--- a/shared_data.py
+++ b/shared_data.py
@@ -16,7 +16,7 @@ class SharedDataModel:
         self.bvid = ttk.StringVar()
         self.part_var = ttk.StringVar()
         self.source_danmaku_filepath = ttk.StringVar()
-
+        self.video_title = ttk.StringVar(value="（未获取到视频标题）")
         self.cid_parts_map = {}  # 存储 {cid: 'title'} 的映射关系
         self.ordered_cids = []  # 存储一个与下拉框显示顺序完全对应的CID列表
         self.selected_cid = None


### PR DESCRIPTION
## Sourcery 总结

通过在整个获取过程中跟踪和显示视频标题来增强弹幕发送器，并在分发弹幕前要求用户确认，并更新应用版本至测试版

新功能：
- 在发送前向用户显示一个确认对话框，其中包含视频标题、分段和弹幕数量

增强功能：
- 在获取、成功和失败状态期间，初始化并更新 UI 中的视频标题

杂项：
- 将应用程序版本提升至 1.1.0-beta.1

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the danmaku sender by tracking and displaying the video title throughout the fetch process and requiring user confirmation before dispatching danmaku, and update the app version to beta

New Features:
- Prompt users with a confirmation dialog showing video title, part, and danmaku count before sending

Enhancements:
- Initialize and update the video title in the UI during fetching, success, and failure states

Chores:
- Bump application version to 1.1.0-beta.1

</details>