### PR TITLE
feat: 新增“打开日志文件夹”菜单选项

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -73,8 +73,7 @@ class Application(ttk.Window):
         if hasattr(self.monitor_tab_frame, 'log_text'):
             self.gui_handler.output_targets["monitor_tab"] = self.log_to_gui_widget(self.monitor_tab_frame.log_text)
 
-        log_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR)) / AppInfo.LOG_DIR_NAME
-        log_dir.mkdir(parents=True, exist_ok=True)
+        log_dir = self.get_log_directory()
         file_handler = DailyLogFileHandler(
             filename=log_dir / AppInfo.LOG_FILE_NAME,
             when='midnight',
@@ -126,6 +125,8 @@ class Application(ttk.Window):
         # --- 文件菜单 ---
         file_menu = ttk.Menu(menu_bar, tearoff=0)
         menu_bar.add_cascade(label="文件", menu=file_menu)
+        file_menu.add_command(label="打开日志文件夹", command=self.open_log_folder)
+        file_menu.add_separator()
         file_menu.add_command(label="退出", command=self.on_closing)
 
         # --- 帮助菜单 ---
@@ -134,6 +135,17 @@ class Application(ttk.Window):
         help_menu.add_command(label=UI.HELP_WINDOW_TITLE, command=self.show_help_window)
         help_menu.add_separator()
         help_menu.add_command(label=UI.ABOUT_WINDOW_SHORT_TITLE, command=self.show_about_window)
+
+    def get_log_directory(self) -> Path:
+        """获取日志文件存储目录"""
+        log_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR)) / AppInfo.LOG_DIR_NAME
+        log_dir.mkdir(parents=True, exist_ok=True)
+        return log_dir
+    
+    def open_log_folder(self):
+        """在文件浏览器中打开日志文件夹"""
+        log_path = self.get_log_directory()
+        webbrowser.open(log_path.as_uri())
 
     def show_help_window(self):
         """显示使用说明窗口"""


### PR DESCRIPTION
通过提供直接访问日志文件的方式提升用户体验并简化故障排除流程。

- 在“文件”菜单中新增“打开日志文件夹”命令
- 该命令使用`webbrowser.open`在系统文件管理器中打开应用程序的日志目录，确保跨平台兼容性
- 将日志目录路径获取功能重构为Application类中的专用`get_log_directory`方法，优化代码组织结构并提高可重用性
- 此项改进解决了用户难以在隐藏的AppData目录中查找日志文件的常见问题

## Sourcery 总结

使用户能够从应用程序菜单快速打开日志文件夹，并通过集中日志目录检索来改进代码组织

新功能：
- 在“文件”菜单中添加“打开日志文件夹”命令，以在系统文件管理器中启动应用程序的日志目录

改进：
- 将日志目录创建重构为 `Application` 类上的专用 `get_log_directory` 方法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable users to quickly open the log folder from the application menu and improve code organization by centralizing log directory retrieval

New Features:
- Add "Open log folder" command to the File menu to launch the application's log directory in the system file manager

Enhancements:
- Refactor log directory creation into a dedicated get_log_directory method on the Application class

</details>