### PR TITLE
chore: 更新构建配置以使用新的入口文件run.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           --icon="assets/icon.ico" `
           --add-data "$ttkbootstrap_path;ttkbootstrap" `
           --add-data "assets;assets" `
-          src/danmaku_sender/ui/main_app.py
+          run.py
 
     - name: Build onedir with Pyinstaller
       run: |
@@ -40,7 +40,7 @@ jobs:
           --icon="assets/icon.ico" `
           --add-data "$ttkbootstrap_path;ttkbootstrap" `
           --add-data "assets;assets" `
-          src/danmaku_sender/ui/main_app.py
+          run.py
 
     - name: Prepare Artifact Names
       id: set_names

--- a/run.py
+++ b/run.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+
+root_dir = Path(__file__).resolve().parent
+src_dir = root_dir / 'src'
+sys.path.insert(0, str(src_dir))
+
+
+from danmaku_sender.ui.main_app import main
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary by Sourcery

引入一个专用的顶层 Python 入口脚本，并更新构建工作流，使其在打包时将该脚本作为应用程序入口。

Enhancements:
- 新增顶层入口脚本 `run.py`，用于初始化源码路径，并将执行委托给现有的主应用入口点。

Build:
- 调整 GitHub Actions 中的 PyInstaller 构建配置，使应用在打包时使用 `run.py` 作为入口脚本，而不是使用 UI 模块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated top-level Python entry point script and update the build workflow to use it as the application entry for packaging.

Enhancements:
- Add a top-level run.py entry script that initializes the source path and delegates to the existing main application entry point.

Build:
- Adjust GitHub Actions PyInstaller build configuration to package the app using run.py as the entry script instead of the UI module.

</details>