### PR TITLE
fix(build): resolve PyInstaller import errors with src layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,25 +24,25 @@ jobs:
         pip install -r requirements.txt
         pip install pyinstaller
 
-    - name: Build onefile EXE with Pyinstaller
+    - name: Build EXE (Onefile & Onedir)
       run: |
         $ttkbootstrap_path = (Get-Command pip).Path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"
-        pyinstaller --noconfirm --onefile --windowed --name "BiliDanmakuSender" `
-          --paths "src" `
-          --icon="assets/icon.ico" `
-          --add-data "$ttkbootstrap_path;ttkbootstrap" `
-          --add-data "assets;assets" `
-          run.py
+        
+        $common_args = @(
+            "--noconfirm",
+            "--windowed",
+            "--paths", "./src",
+            "--icon=assets/icon.ico",
+            "--add-data", "$ttkbootstrap_path;ttkbootstrap",
+            "--add-data", "assets;assets",
+            "run.py"
+        )
 
-    - name: Build onedir with Pyinstaller
-      run: |
-        $ttkbootstrap_path = (Get-Command pip).Path | Split-Path | Join-Path -ChildPath "..\Lib\site-packages\ttkbootstrap"
-        pyinstaller --noconfirm --onedir --windowed --name "BiliDanmakuSender_onedir" `
-          --paths "src" `
-          --icon="assets/icon.ico" `
-          --add-data "$ttkbootstrap_path;ttkbootstrap" `
-          --add-data "assets;assets" `
-          run.py
+        Write-Host "Building Onefile version..."
+        pyinstaller --onefile --name "BiliDanmakuSender" @common_args
+
+        Write-Host "Building Onedir version..."
+        pyinstaller --onedir --name "BiliDanmakuSender_onedir" @common_args
 
     - name: Prepare Artifact Names
       id: set_names


### PR DESCRIPTION
- 为 `build.yml` 添加 `--paths "src"` 配置，确保 PyInstaller 能找到 `danmaku_sender` 包。

## Summary by Sourcery

Build:
- 更新 GitHub Actions 构建工作流，将 `src` 目录传递给 PyInstaller，并在 Onefile 和 Onedir 构建之间共享通用参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update GitHub Actions build workflow to pass the src directory to PyInstaller and share common arguments between Onefile and Onedir builds.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- 更新 GitHub Actions 构建工作流，将 `src` 目录传递给 PyInstaller，并在 Onefile 和 Onedir 构建之间共享通用参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update GitHub Actions build workflow to pass the src directory to PyInstaller and share common arguments between Onefile and Onedir builds.

</details>

</details>