### PR TITLE
fix: Fix swapped message and title arguments in ValidatorTab

### DIFF
--- a/src/danmaku_sender/ui/validator_tab.py
+++ b/src/danmaku_sender/ui/validator_tab.py
@@ -117,7 +117,7 @@ class ValidatorTab(ttk.Frame):
         """删除在Treeview中选中的条目"""
         selected_items = self.tree.selection()
         if not selected_items:
-            Messagebox.show_warning("未选择", "请先选择要删除的弹幕条目。", parent=self.app)
+            Messagebox.show_warning("请先选择要删除的弹幕条目。", "未选择", parent=self.app)
             return
         
         if messagebox.askyesno("确认删除", f"确定要从问题列表中移除这 {len(selected_items)} 条弹幕吗？\n（应用修改后将从发送队列中删除）", parent=self.app):
@@ -127,7 +127,7 @@ class ValidatorTab(ttk.Frame):
     def apply_changes(self):
         """应用更改，重建并更新共享模型中的弹幕列表"""
         if not self.original_danmakus_snapshot:
-            Messagebox.show_warning("未进行验证", "请先运行一次验证，再应用修改。", parent=self.app)
+            Messagebox.show_warning("请先运行一次验证，再应用修改。", "未进行验证", parent=self.app)
             return
         
         modified_issues = {


### PR DESCRIPTION
修复了 `ValidatorTab` 中 `Messagebox.show_warning` 调用的参数顺序问题。
之前的代码错误地将“提示信息”和“窗口标题”写反了，导致弹窗内容显示不直观。

**修改前 (Before):**
`show_warning("标题", "长文本内容")` -> 导致内容区只显示标题，标题栏显示长文本。

**修改后 (After):**
`show_warning("长文本内容", "标题")` -> 也就是符合 `(message, title)` 的标准顺序。

## 修改文件 (Files changed)
- `ui/validator_tab.py`

## Summary by Sourcery

错误修复：
- 修正 ValidatorTab 警告弹窗在未选择项目或尚未运行校验时，`message` 和 `title` 参数的顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the message and title parameter order for ValidatorTab warning popups when no item is selected or validation has not been run.

</details>