### PR TITLE
fix: 优化任务结算流程以防止系统级 GUI 挂起

### DIFF
--- a/src/danmaku_sender/ui/sender_tab.py
+++ b/src/danmaku_sender/ui/sender_tab.py
@@ -369,6 +369,13 @@ class SenderTab(ttk.Frame):
 
     def _ask_save_unsent_danmakus(self, sender: BiliDanmakuSender):
         """独立的逻辑处理函数，仅负责弹窗和保存"""
+        if not self.winfo_exists():
+            return
+
+        if not sender.unsent_danmakus:
+            self.logger.info("所有弹幕均已成功发送，或无未发送弹幕。")
+            return
+        
         self.logger.info(f"检测到 {len(sender.unsent_danmakus)} 条弹幕未发送成功。")
 
         should_save = messagebox.askyesno(
@@ -378,7 +385,7 @@ class SenderTab(ttk.Frame):
             parent=self.app
         )
 
-        if should_save is True:
+        if should_save:
             file_path_str = filedialog.asksaveasfilename(
                 title="保存未发送弹幕为XML文件",
                 defaultextension=".xml",
@@ -390,10 +397,8 @@ class SenderTab(ttk.Frame):
                 self.logger.info(f"已将未发送弹幕保存到 '{file_path_str}'。")
             else:
                 self.logger.info("用户取消了文件路径选择。")
-        elif should_save is False:
-            self.logger.info("用户选择不保存未发送弹幕。")
         else:
-            self.logger.info("用户关闭了弹窗，未选择保存或不保存未发送弹幕。")
+            self.logger.info("用户选择不保存未发送弹幕。")
 
     def stop_task(self):
         """停止发送弹幕任务的逻辑"""


### PR DESCRIPTION
在 UI 线程引入 100ms 异步延迟触发结算弹窗。

## Summary by Sourcery

优化弹幕发送任务的收尾流程，避免界面卡死并改进未发送弹幕的处理。

Bug Fixes（问题修复）:
- 通过在 UI 线程上使用短延时回调来触发“未发送弹幕保存”对话框，以降低图形界面卡死的风险。
- 为“未发送弹幕保存”流程增加保护，以应对 UI 窗口已被销毁的情况。

Enhancements（优化改进）:
- 将“未发送弹幕保存”对话框的逻辑提取到一个专用的辅助方法中，以实现更清晰的职责分离。
- 改进日志记录：在没有未发送弹幕时明确记录流程已成功完成，并区分用户在保存对话框中的不同选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the danmaku sending task finalization flow to avoid UI hangs and improve handling of unsent messages.

Bug Fixes:
- Trigger the unsent-danmaku save dialog via a short delayed callback on the UI thread to reduce risk of GUI freezes.
- Guard the unsent-danmaku save flow against cases where the UI window has already been destroyed.

Enhancements:
- Extract the unsent-danmaku save dialog logic into a dedicated helper method for clearer separation of concerns.
- Improve logging to explicitly record successful completion when there are no unsent danmakus and to distinguish different user choices in the save dialog.

</details>

Bug Fixes（错误修复）:
- 通过在 UI 线程上以一个短暂的异步延迟触发保存未发送弹幕的对话框，防止潜在的 GUI 卡顿。

Enhancements（增强改进）:
- 将未发送弹幕保存对话框的流程提取到独立的辅助方法中，以实现更清晰的职责分离。
- 改进日志记录，在没有未发送弹幕时也能明确记录任务成功完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化弹幕发送任务的收尾流程，避免界面卡死并改进未发送弹幕的处理。

Bug Fixes（问题修复）:
- 通过在 UI 线程上使用短延时回调来触发“未发送弹幕保存”对话框，以降低图形界面卡死的风险。
- 为“未发送弹幕保存”流程增加保护，以应对 UI 窗口已被销毁的情况。

Enhancements（优化改进）:
- 将“未发送弹幕保存”对话框的逻辑提取到一个专用的辅助方法中，以实现更清晰的职责分离。
- 改进日志记录：在没有未发送弹幕时明确记录流程已成功完成，并区分用户在保存对话框中的不同选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the danmaku sending task finalization flow to avoid UI hangs and improve handling of unsent messages.

Bug Fixes:
- Trigger the unsent-danmaku save dialog via a short delayed callback on the UI thread to reduce risk of GUI freezes.
- Guard the unsent-danmaku save flow against cases where the UI window has already been destroyed.

Enhancements:
- Extract the unsent-danmaku save dialog logic into a dedicated helper method for clearer separation of concerns.
- Improve logging to explicitly record successful completion when there are no unsent danmakus and to distinguish different user choices in the save dialog.

</details>

</details>