### PR TITLE
fix: 修复打开日志文件夹意外触发浏览器的问题

### DIFF
--- a/src/danmaku_sender/ui/main_app.py
+++ b/src/danmaku_sender/ui/main_app.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from pathlib import Path
 from platformdirs import user_data_dir
@@ -164,7 +165,13 @@ class Application(ttk.Window):
     def open_log_folder(self):
         """在文件浏览器中打开日志文件夹"""
         log_path = self.get_log_directory()
-        webbrowser.open(log_path.as_uri())
+        try:
+            if log_path.exists():
+                os.startfile(log_path)
+            else:
+                self.logger.error(f"日志文件夹不存在: {log_path}")
+        except Exception as e:
+            self.logger.error(f"无法打开日志文件夹: {e}")
 
     def show_help_window(self):
         """显示使用说明窗口"""


### PR DESCRIPTION
1. 弃用 webbrowser.open(path.as_uri())，该方法在部分 Windows 环境下会因 file:// 协议关联问题导致在浏览器中打开文件夹。
2. 改用 Windows 原生的 os.startfile()，确保始终调用系统资源管理器 (Explorer) 打开目录。
3. 增强了对路径存在性的预检和异常捕获。

## Summary by Sourcery

更稳健地处理日志目录的打开行为，以避免启动网页浏览器，并在无法打开文件夹时改进错误处理。

Bug Fixes:
- 确保使用系统文件资源管理器打开日志目录，而不是在某些 Windows 环境中可能会启动网页浏览器。

Enhancements:
- 在尝试打开日志目录时添加存在性检查和异常处理，并在失败时记录清晰的错误消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle opening the log directory more robustly to avoid launching a web browser and improve error handling when the folder cannot be opened.

Bug Fixes:
- Ensure the log directory is opened with the system file explorer instead of potentially launching a web browser on some Windows environments.

Enhancements:
- Add existence checks and exception handling when attempting to open the log directory, logging clear error messages on failure.

</details>