### PR TITLE
feat(sender): 阻止在校验器有未应用修改时启动发送任务

### DIFF
--- a/src/danmaku_sender/ui/sender_tab.py
+++ b/src/danmaku_sender/ui/sender_tab.py
@@ -409,7 +409,7 @@ class SenderTab(QWidget):
         # 校验
         state = self._state
 
-        if self._state.validator_is_dirty:
+        if state.validator_is_dirty:
             QMessageBox.warning(
                 self, 
                 "存在未保存的修改", 


### PR DESCRIPTION
## Summary by Sourcery

当弹幕校验器中存在未应用的更改时，发出警告并阻止启动发送任务，并修复凭证检查附近的一些缩进和格式问题。

新功能：
- 添加预检查：当弹幕校验器中存在未保存的修改时，阻止启动发送任务，并通过警告对话框告知用户。

错误修复：
- 修正发送任务切换处理程序中“凭证缺失”警告检查的缩进问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Warn and block starting a send task when there are unapplied changes in the danmaku validator, and fix minor indentation/formatting around credential checks.

New Features:
- Add a pre-flight check that prevents starting the send task if the danmaku validator has unsaved modifications and informs the user via a warning dialog.

Bug Fixes:
- Correct the indentation of the credential-missing warning check in the send task toggle handler.

</details>