### PR TITLE
feat(monitor): 重构监视器为数据库审计模式并升级仪表盘UI

### DIFF
--- a/src/danmaku_sender/core/state.py
+++ b/src/danmaku_sender/core/state.py
@@ -56,7 +56,6 @@ class SenderConfig:
 class MonitorConfig:
     """监视器的配置数据"""
     refresh_interval: int = 60  # 刷新间隔，单位秒
-    tolerance: int = 500
     
     # 复用全局设置
     prevent_sleep: bool = True


### PR DESCRIPTION
[核心变更]
1. 监视逻辑重构 (Database Audit):
   - 弃用基于文本相似度的本地比对逻辑。
   - 实现基于 `dmid` 的数据库精确核销：拉取在线列表 -> 提取ID -> 数据库验证 (Pending -> Verified)。
   - 移除 `MonitorConfig` 中已废弃的 `tolerance` (时间容差) 参数。

2. UI 交互升级 (Dashboard):
   - `MonitorTab`: 移除进度条，替换为实时数据仪表盘，显示 总数/存活/待验/丢失 四项核心指标。
   - 适配 `MonitorTaskWorker` 新的 `stats_updated` 信号 (传递 dict 数据)。

3. 架构优化:
   - `Monitor`: 构造函数改为接收 `VideoTarget` 对象，统一了 Sender 和 Monitor 的目标传递方式。
   - `Worker`: 修正 `MonitorTaskWorker` 信号定义，补充缺失的 `status_updated` 信号，防止 UI 崩溃。

[Bug 修复]
- fix(core): 修复 `HistoryManager.verify_dmids` 在无更新时返回 None 导致类型错误的 Bug。
- fix(core): 修复 `verify_dmids` 计数逻辑，现在仅统计状态真正发生变更 (Pending->Verified) 的行数。

[影响范围]
- 监视器不再需要加载本地弹幕文件即可工作（只要 Sender 选定目标）。

## Summary by Sourcery

重构监控系统，使其使用基于数据库的弹幕发送审计机制，并在仪表盘 UI 中展示新的聚合统计数据。

新功能：
- 新增仪表盘风格的监控标签页，用于展示当前视频目标的弹幕总数、已验证数、待验证数以及丢失数。
- 从监控 worker 向 UI 暴露每个目标的审计统计信息，通过新的 `stats_updated` 信号传递包含统计数据的字典。

错误修复：
- 确保 `HistoryManager.verify_dmids` 只统计并更新状态实际从「待验证」变为「已验证」的行，并且始终返回一个整数计数。

改进：
- 重构 `BiliDanmakuMonitor`，使其基于 `VideoTarget` 使用数据库进行验证，而不是通过本地文件相似度匹配，从而不再需要本地弹幕文件。
- 简化监控配置，移除已废弃的时间容差参数，并收紧最小轮询间隔。
- 更新监控标签页布局，将重点放在目标信息和统计数据上，而不是基于文件的细节和进度条，从而提高在缺失本地文件时的清晰度和鲁棒性。
- 使 `MonitorTaskWorker` 与新的监控 API 对齐，包括基于审计统计信息生成更清晰的状态消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the monitoring system to use database-backed audit of sent danmaku and expose new aggregated stats to the dashboard UI.

New Features:
- Add a dashboard-style monitor tab showing total, verified, pending, and lost danmaku counts for the current video target.
- Expose per-target audit statistics from the monitor worker to the UI via a new stats_updated signal carrying a stats dictionary.

Bug Fixes:
- Ensure HistoryManager.verify_dmids only counts and updates rows whose status actually changes from pending to verified, and always returns an integer count.

Enhancements:
- Refactor BiliDanmakuMonitor to operate on a VideoTarget with database-based verification instead of local file similarity matching, removing the need for local danmaku files.
- Simplify monitor configuration by removing the obsolete time tolerance parameter and tightening the minimum polling interval.
- Update monitor tab layout to focus on target information and stats instead of file-based details and progress bar, improving clarity and resilience to missing local files.
- Align MonitorTaskWorker to the new monitor API, including cleaner status messages derived from audit stats.

</details>