### PR TITLE
refactor: 规范化 PySide 类型标注并修复 Pylance 静态检查报错

### DIFF
--- a/src/danmaku_sender/api/bili_api_client.py
+++ b/src/danmaku_sender/api/bili_api_client.py
@@ -26,7 +26,7 @@ class BiliApiClient:
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
         'Referer': 'https://www.bilibili.com/'
     }
-    def __init__(self, sessdata: str, bili_jct: str, use_system_proxy: bool, logger: logging.Logger = None):
+    def __init__(self, sessdata: str, bili_jct: str, use_system_proxy: bool, logger: logging.Logger | None = None):
         if not all([sessdata, bili_jct]):
             raise ValueError("SESSDATA 和 BILI_JCT 不能为空")
         
@@ -43,7 +43,7 @@ class BiliApiClient:
             raise BiliApiException(code=-1, message=f"获取WBI签名密钥失败: {e}") from e
 
     @classmethod
-    def from_config(cls, config: BiliConfigProto, logger: logging.Logger = None):
+    def from_config(cls, config: BiliConfigProto, logger: logging.Logger | None = None):
         """
         工厂方法：直接从配置对象创建实例。
         鸭子类型：只要 config 对象里有 sessdata, bili_jct, use_system_proxy 属性即可。
@@ -67,7 +67,7 @@ class BiliApiClient:
         if not self.use_system_proxy:
             self.logger.info("用户已关闭系统代理选项，将强制直连。")
             session.trust_env = False
-            session.proxies = {"http": None, "https": None}
+            session.proxies = {}
         return session
     
     def close(self):

--- a/src/danmaku_sender/api/update_checker.py
+++ b/src/danmaku_sender/api/update_checker.py
@@ -24,7 +24,7 @@ class UpdateChecker:
         session = requests.Session()
         if not use_system_proxy:
             session.trust_env = False
-            session.proxies = {"http": None, "https": None}
+            session.proxies = {}
 
         api_url = f"{Links.GITHUB_API_RELEASES}?per_page=1"
         logger.info("正在连接 GitHub 检查更新...")

--- a/src/danmaku_sender/core/bili_sender.py
+++ b/src/danmaku_sender/core/bili_sender.py
@@ -106,15 +106,15 @@ class BiliDanmakuSender:
         except BiliApiException as e:
             error_code_enum = normalize_exception(e)
             
-            log_message = f"❌ 发送异常! 内容: '{danmaku.get('msg', 'N/A')}', 错误: {e.message}"
+            log_message = f"❌ 发送异常! 内容: '{danmaku.msg}', 错误: {e.message}"
             self.logger.error(log_message)
             return DanmakuSendResult(
                 code=error_code_enum.code,
-                success=False,
-                message=str(e),
+                is_success=False,
+                raw_message=str(e),
                 display_message=error_code_enum.description_str
             )
-        
+
     def _should_skip(self, dm: Danmaku, ctx: SendingContext, history_manager: HistoryManager | None) -> bool:
         """判断是否需要跳过当前弹幕"""
         if not ctx.config.skip_sent or not history_manager:

--- a/src/danmaku_sender/core/history_manager.py
+++ b/src/danmaku_sender/core/history_manager.py
@@ -128,7 +128,7 @@ class HistoryManager:
         将状态更新为: STATUS_VERIFIED (1)
         """
         if not verified_dmids:
-            return
+            return 0
 
         try:
             with self._get_conn() as conn:

--- a/src/danmaku_sender/core/services/video_fetcher.py
+++ b/src/danmaku_sender/core/services/video_fetcher.py
@@ -11,7 +11,7 @@ class VideoFetcher:
     视频业务服务层
     负责协调 API 调用与数据转换
     """
-    def __init__(self, api_client: BiliApiClient, logger: logging.Logger = None):
+    def __init__(self, api_client: BiliApiClient, logger: logging.Logger | None = None):
         self.client = api_client
         self.logger = logger if logger else logging.getLogger("VideoFetcher")
 

--- a/src/danmaku_sender/ui/dialogs.py
+++ b/src/danmaku_sender/ui/dialogs.py
@@ -19,7 +19,7 @@ class MarkdownBrowser(QTextBrowser):
     def __init__(self, doc_name: str):
         super().__init__()
         self.setOpenExternalLinks(True)
-        self.setFrameShape(QTextBrowser.NoFrame)
+        self.setFrameShape(QTextBrowser.Shape.NoFrame)
         self.setStyleSheet("padding: 1px;") 
         
         md_path = get_assets_path() / "docs" / f"{doc_name}.md"
@@ -81,26 +81,26 @@ class AboutDialog(QDialog):
 
     def _create_ui(self):
         layout = QVBoxLayout(self)
-        layout.setAlignment(Qt.AlignCenter)
+        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.setSpacing(8)
         
         # 标题
         title = QLabel(AppInfo.NAME)
         title.setStyleSheet("font-size: 18px; font-weight: bold; color: #fb7299;")
-        layout.addWidget(title, alignment=Qt.AlignCenter)
+        layout.addWidget(title, alignment=Qt.AlignmentFlag.AlignCenter)
 
         # 版本与作者
-        layout.addWidget(QLabel(f"v{AppInfo.VERSION}"), alignment=Qt.AlignCenter)
-        layout.addWidget(QLabel(f"By {AppInfo.AUTHOR}"), alignment=Qt.AlignCenter)
+        layout.addWidget(QLabel(f"v{AppInfo.VERSION}"), alignment=Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(QLabel(f"By {AppInfo.AUTHOR}"), alignment=Qt.AlignmentFlag.AlignCenter)
 
         layout.addSpacing(15)
 
         # 链接区域
         repo_btn = QPushButton("GitHub 仓库")
-        repo_btn.setCursor(Qt.PointingHandCursor)
+        repo_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         repo_btn.setStyleSheet("color: #00a1d6; border: none; text-decoration: underline; background: transparent;")
         repo_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(Links.GITHUB_REPO)))
-        layout.addWidget(repo_btn, alignment=Qt.AlignCenter)
+        layout.addWidget(repo_btn, alignment=Qt.AlignmentFlag.AlignCenter)
 
         # 反馈文案 (直接写在这里，修改看这里就行)
         feedback_text = (
@@ -108,14 +108,14 @@ class AboutDialog(QDialog):
             "欢迎前往 GitHub Issues 页面提交反馈。"
         )
         feedback = QLabel(feedback_text)
-        feedback.setAlignment(Qt.AlignCenter)
+        feedback.setAlignment(Qt.AlignmentFlag.AlignCenter)
         feedback.setWordWrap(True)
         feedback.setStyleSheet("color: #666; font-size: 12px; margin: 10px;")
         layout.addWidget(feedback)
 
         # Issue 链接
         issue_btn = QPushButton(">>> 前往反馈页面 <<<")
-        issue_btn.setCursor(Qt.PointingHandCursor)
+        issue_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         issue_btn.setStyleSheet("color: #00a1d6; border: none; background: transparent;")
         issue_btn.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(Links.GITHUB_ISSUES)))
         layout.addWidget(issue_btn)
@@ -126,7 +126,7 @@ class AboutDialog(QDialog):
         close_btn = QPushButton("关闭")
         close_btn.setFixedWidth(100)
         close_btn.clicked.connect(self.accept)
-        layout.addWidget(close_btn, alignment=Qt.AlignCenter)
+        layout.addWidget(close_btn, alignment=Qt.AlignmentFlag.AlignCenter)
 
 
 class UpdateDialog(QDialog):

--- a/src/danmaku_sender/ui/monitor_tab.py
+++ b/src/danmaku_sender/ui/monitor_tab.py
@@ -51,11 +51,11 @@ class MonitorTab(QWidget):
 
         def create_stat_block(title, color):
             lbl_num = QLabel("0")
-            lbl_num.setAlignment(Qt.AlignCenter)
+            lbl_num.setAlignment(Qt.AlignmentFlag.AlignCenter)
             lbl_num.setStyleSheet(f"font-size: 32px; font-weight: bold; color: {color}; font-family: 'Segoe UI', sans-serif;")
             
             lbl_title = QLabel(title)
-            lbl_title.setAlignment(Qt.AlignCenter)
+            lbl_title.setAlignment(Qt.AlignmentFlag.AlignCenter)
             lbl_title.setStyleSheet("color: #7f8c8d; font-size: 12px;")
 
             container = QVBoxLayout()
@@ -108,7 +108,7 @@ class MonitorTab(QWidget):
         
         self.start_btn = QPushButton("开始监视")
         self.start_btn.setFixedWidth(100)
-        self.start_btn.setCursor(Qt.PointingHandCursor)
+        self.start_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self.start_btn.setProperty("action", "true")
         self.start_btn.setProperty("state", "ready")
         
@@ -251,4 +251,4 @@ class MonitorTab(QWidget):
 
     def append_log(self, message: str):
         self.log_output.append(message)
-        self.log_output.moveCursor(QTextCursor.End)
+        self.log_output.moveCursor(QTextCursor.MoveOperation.End)

--- a/src/danmaku_sender/ui/sender_tab.py
+++ b/src/danmaku_sender/ui/sender_tab.py
@@ -110,8 +110,8 @@ class SenderTab(QWidget):
         # 分隔线
         delay_layout.addSpacing(15)
         v_line = QFrame()
-        v_line.setFrameShape(QFrame.VLine)
-        v_line.setFrameShadow(QFrame.Sunken)
+        v_line.setFrameShape(QFrame.Shape.VLine)
+        v_line.setFrameShadow(QFrame.Shadow.Sunken)
         delay_layout.addWidget(v_line)
         delay_layout.addSpacing(15)
 
@@ -160,8 +160,8 @@ class SenderTab(QWidget):
 
         stop_layout.addSpacing(20)
         v_line2 = QFrame()
-        v_line2.setFrameShape(QFrame.VLine)
-        v_line2.setFrameShadow(QFrame.Sunken)
+        v_line2.setFrameShape(QFrame.Shape.VLine)
+        v_line2.setFrameShadow(QFrame.Shadow.Sunken)
         stop_layout.addWidget(v_line2)
         stop_layout.addSpacing(20)
 
@@ -198,7 +198,7 @@ class SenderTab(QWidget):
         self.progress_bar.setValue(0)
         self.start_btn = QPushButton("开始发送")
         self.start_btn.setFixedWidth(100)
-        self.start_btn.setCursor(Qt.PointingHandCursor)
+        self.start_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self.start_btn.setProperty("action", "true")
         self.start_btn.setProperty("state", "ready")
 
@@ -292,7 +292,7 @@ class SenderTab(QWidget):
     def append_log(self, message: str):
         """外部调用的日志接口"""
         self.log_output.append(message) 
-        self.log_output.moveCursor(QTextCursor.End)
+        self.log_output.moveCursor(QTextCursor.MoveOperation.End)
 
     def select_file(self):
         """文件选择逻辑"""
@@ -504,9 +504,9 @@ class SenderTab(QWidget):
             reply = QMessageBox.question(
                 self, "保存失败弹幕", 
                 f"有 {count} 条弹幕发送失败。\n是否保存为新的 XML 文件以便重新发送？",
-                QMessageBox.Yes | QMessageBox.No
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
             )
-            if reply == QMessageBox.Yes:
+            if reply == QMessageBox.StandardButton.Yes:
                 file_path, _ = QFileDialog.getSaveFileName(self, "保存XML", "unsent.xml", "XML Files (*.xml)")
                 if file_path:
                     try:

--- a/src/danmaku_sender/ui/settings_tab.py
+++ b/src/danmaku_sender/ui/settings_tab.py
@@ -23,16 +23,16 @@ class SettingsTab(QWidget):
         # --- 身份凭证 ---
         auth_group = QGroupBox("身份凭证 (Cookie)")
         auth_layout = QFormLayout()
-        auth_layout.setLabelAlignment(Qt.AlignRight)
+        auth_layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
 
         self.sessdata_input = QLineEdit()
         self.sessdata_input.setPlaceholderText("请输入您的 SESSDATA")
-        self.sessdata_input.setEchoMode(QLineEdit.Password)
+        self.sessdata_input.setEchoMode(QLineEdit.EchoMode.Password)
         self.sessdata_input.setToolTip("SESSDATA 用于身份验证，请妥善保管。")
 
         self.bili_jct_input = QLineEdit()
         self.bili_jct_input.setPlaceholderText("请输入您的 bili_jct")
-        self.bili_jct_input.setEchoMode(QLineEdit.Password)
+        self.bili_jct_input.setEchoMode(QLineEdit.EchoMode.Password)
         self.bili_jct_input.setToolTip("bili_jct 用于请求验证，请妥善保管。")
 
         auth_layout.addRow(QLabel("SESSDATA:"), self.sessdata_input)

--- a/src/danmaku_sender/ui/validator_tab.py
+++ b/src/danmaku_sender/ui/validator_tab.py
@@ -67,22 +67,22 @@ class ValidatorTab(QWidget):
         self.table.setHorizontalHeaderLabels(["序号", "时间", "问题描述", "弹幕内容 (双击编辑)"])
 
         # 设置表格行为
-        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
-        self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.table.setAlternatingRowColors(True)
         self.table.setSortingEnabled(False)
         self.table.itemDoubleClicked.connect(self.on_table_double_click)
 
         # 右键菜单
-        self.table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.table.customContextMenuRequested.connect(self.open_context_menu)
 
         # 设置列宽调整模式
         header = self.table.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
-        header.setSectionResizeMode(3, QHeaderView.Stretch)
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
 
         main_layout.addWidget(self.table)
 
@@ -184,7 +184,7 @@ class ValidatorTab(QWidget):
         # 检查未保存修改
         if self.session.is_dirty:
             reply = QMessageBox.question(self, "确认", "当前有未应用的修改，重新验证将丢弃这些修改。\n是否继续？", QMessageBox.Yes | QMessageBox.No)
-            if reply == QMessageBox.No:
+            if reply == QMessageBox.StandardButton.No:
                 return
             
         # 执行验证
@@ -206,7 +206,7 @@ class ValidatorTab(QWidget):
         self.table.setRowCount(len(items))
         for row, item in enumerate(items):
             idx_item = QTableWidgetItem(str(item['original_index'] + 1))
-            idx_item.setData(Qt.UserRole, item['original_index'])
+            idx_item.setData(Qt.ItemDataRole.UserRole, item['original_index'])
             
             time_str = format_ms_to_hhmmss(item['time_ms'])
             
@@ -233,7 +233,7 @@ class ValidatorTab(QWidget):
             self._edit_row(item.row())
         elif action == delete_action:
             # 获取原始索引并删除
-            original_index = self.table.item(item.row(), 0).data(Qt.UserRole)
+            original_index = self.table.item(item.row(), 0).data(Qt.ItemDataRole.UserRole)
             self.session.delete_item(original_index)
             self._refresh_table()
 
@@ -247,7 +247,7 @@ class ValidatorTab(QWidget):
         if not idx_item:
             return
         
-        original_index = idx_item.data(Qt.UserRole)
+        original_index = idx_item.data(Qt.ItemDataRole.UserRole)
         current_text = self.table.item(row, 3).text()
 
         new_text, ok = QInputDialog.getText(self, "编辑弹幕", "请输入修改后的内容：", text=current_text)
@@ -259,8 +259,8 @@ class ValidatorTab(QWidget):
                     self.session.update_item_content(original_index, clean_text)
                     self._refresh_table()
             else:
-                reply = QMessageBox.question(self, "确认删除", "内容为空，是否直接删除该条弹幕？", QMessageBox.Yes | QMessageBox.No)
-                if reply == QMessageBox.Yes:
+                reply = QMessageBox.question(self, "确认删除", "内容为空，是否直接删除该条弹幕？", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+                if reply == QMessageBox.StandardButton.Yes:
                     self.session.delete_item(original_index)
                     self._refresh_table()
 
@@ -277,7 +277,7 @@ class ValidatorTab(QWidget):
             return
 
         for row in rows:
-            original_index = self.table.item(row, 0).data(Qt.UserRole)
+            original_index = self.table.item(row, 0).data(Qt.ItemDataRole.UserRole)
             self.session.delete_item(original_index)
 
         self._refresh_table()


### PR DESCRIPTION
- 将 PySide 枚举简写替换为全称 (例如QMessageBox.Yes -> QMessageBox.StandardButton.Yes)
- 修复 `_create_session` 中 `proxies` 属性被分配为 None 的类型不匹配问题
- 修复 `verify_dmids` 在空输入时返回 None 导致的类型冲突 (改为返回 0)

## Summary by Sourcery

在 UI 和核心模块中规范 Qt/PySide 枚举的使用方式和类型注解，以满足静态分析要求，同时让弹幕发送和历史记录处理行为与其数据模型保持一致。

Bug 修复：
- 当系统代理被禁用时，确保 HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 使 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保证其公共 API 始终返回整数。
- 将弹幕发送错误处理逻辑与 `Danmaku` 和 `DanmakuSendResult` 数据模型对齐，修复属性名与字段名不一致的问题。

功能增强：
- 用全限定名称替换 Qt/PySide 的简写枚举、标志、光标形状、边框形状、缩放模式、上下文菜单策略、条目角色和对齐标志，以获得更清晰的语义和更好的工具支持。
- 在 API 和服务类中收紧可选日志记录器参数类型，将其显式标注为 `logging.Logger | None`。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提升可读性并改善与静态类型检查的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Qt/PySide enum usages and type annotations across UI and core modules to satisfy static analysis while aligning danmaku sending and history handling behavior with their data models.

Bug Fixes:
- Ensure HTTP sessions use an empty proxy mapping instead of None when system proxies are disabled to avoid type mismatches.
- Make HistoryManager.verify_dmids return 0 for empty input so its public API consistently returns an integer.
- Align danmaku send error handling with the Danmaku and DanmakuSendResult data models, fixing attribute and field name mismatches.

Enhancements:
- Replace shorthand Qt/PySide enums, flags, cursor shapes, frame shapes, resize modes, context menu policies, item roles, and alignment flags with fully qualified members for clearer semantics and better tooling support.
- Tighten optional logger parameters in API and service classes by annotating them explicitly as logging.Logger | None.
- Use more specific QTextCursor and QMessageBox enum members in UI code to improve readability and static type checking compatibility.

</details>

Bug 修复：
- 当系统代理被禁用时，HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 让 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保持其返回类型始终为整数。
- 将弹幕发送的错误处理与 `DanmakuSendResult` 数据模型字段对齐，以避免属性和类型问题。

增强项：
- 将 PySide Qt 的枚举、标志、光标形状、框架形状、调整大小模式、上下文菜单策略、条目角色以及对齐标志替换为完全限定的成员名称，以获得更清晰的语义并提升工具支持。
- 在 API 和服务类中收紧可选 logger 参数的类型注解，显式使用 `Optional[logging.Logger]` 类型。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提高可读性并增强对静态分析的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 UI 和核心模块中规范 Qt/PySide 枚举的使用方式和类型注解，以满足静态分析要求，同时让弹幕发送和历史记录处理行为与其数据模型保持一致。

Bug 修复：
- 当系统代理被禁用时，确保 HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 使 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保证其公共 API 始终返回整数。
- 将弹幕发送错误处理逻辑与 `Danmaku` 和 `DanmakuSendResult` 数据模型对齐，修复属性名与字段名不一致的问题。

功能增强：
- 用全限定名称替换 Qt/PySide 的简写枚举、标志、光标形状、边框形状、缩放模式、上下文菜单策略、条目角色和对齐标志，以获得更清晰的语义和更好的工具支持。
- 在 API 和服务类中收紧可选日志记录器参数类型，将其显式标注为 `logging.Logger | None`。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提升可读性并改善与静态类型检查的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Qt/PySide enum usages and type annotations across UI and core modules to satisfy static analysis while aligning danmaku sending and history handling behavior with their data models.

Bug Fixes:
- Ensure HTTP sessions use an empty proxy mapping instead of None when system proxies are disabled to avoid type mismatches.
- Make HistoryManager.verify_dmids return 0 for empty input so its public API consistently returns an integer.
- Align danmaku send error handling with the Danmaku and DanmakuSendResult data models, fixing attribute and field name mismatches.

Enhancements:
- Replace shorthand Qt/PySide enums, flags, cursor shapes, frame shapes, resize modes, context menu policies, item roles, and alignment flags with fully qualified members for clearer semantics and better tooling support.
- Tighten optional logger parameters in API and service classes by annotating them explicitly as logging.Logger | None.
- Use more specific QTextCursor and QMessageBox enum members in UI code to improve readability and static type checking compatibility.

</details>

</details>

Bug 修复：
- 确保 HTTP 会话的代理配置在系统代理被禁用时使用空映射而不是 `None`，以避免类型不匹配。
- 让 `HistoryManager.verify_dmids` 在输入为空时返回整数 `0` 而不是 `None`，以保持其返回类型的一致性。
- 将弹幕发送错误处理逻辑与 `Danmaku/DanmakuSendResult` 数据模型字段对齐，解决类型和属性访问问题。

增强：
- 统一将 PySide Qt 的枚举、标志、光标、边框以及 item role 的引用改为完整限定成员名称，以提升代码清晰度和工具支持度。
- 在 API 和服务类中为可选的 logger 参数显式添加 `Optional` 类型标注，以改善静态类型检查效果。
- 使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提高可读性并更有利于静态分析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 UI 和核心模块中规范 Qt/PySide 枚举的使用方式和类型注解，以满足静态分析要求，同时让弹幕发送和历史记录处理行为与其数据模型保持一致。

Bug 修复：
- 当系统代理被禁用时，确保 HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 使 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保证其公共 API 始终返回整数。
- 将弹幕发送错误处理逻辑与 `Danmaku` 和 `DanmakuSendResult` 数据模型对齐，修复属性名与字段名不一致的问题。

功能增强：
- 用全限定名称替换 Qt/PySide 的简写枚举、标志、光标形状、边框形状、缩放模式、上下文菜单策略、条目角色和对齐标志，以获得更清晰的语义和更好的工具支持。
- 在 API 和服务类中收紧可选日志记录器参数类型，将其显式标注为 `logging.Logger | None`。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提升可读性并改善与静态类型检查的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Qt/PySide enum usages and type annotations across UI and core modules to satisfy static analysis while aligning danmaku sending and history handling behavior with their data models.

Bug Fixes:
- Ensure HTTP sessions use an empty proxy mapping instead of None when system proxies are disabled to avoid type mismatches.
- Make HistoryManager.verify_dmids return 0 for empty input so its public API consistently returns an integer.
- Align danmaku send error handling with the Danmaku and DanmakuSendResult data models, fixing attribute and field name mismatches.

Enhancements:
- Replace shorthand Qt/PySide enums, flags, cursor shapes, frame shapes, resize modes, context menu policies, item roles, and alignment flags with fully qualified members for clearer semantics and better tooling support.
- Tighten optional logger parameters in API and service classes by annotating them explicitly as logging.Logger | None.
- Use more specific QTextCursor and QMessageBox enum members in UI code to improve readability and static type checking compatibility.

</details>

Bug 修复：
- 当系统代理被禁用时，HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 让 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保持其返回类型始终为整数。
- 将弹幕发送的错误处理与 `DanmakuSendResult` 数据模型字段对齐，以避免属性和类型问题。

增强项：
- 将 PySide Qt 的枚举、标志、光标形状、框架形状、调整大小模式、上下文菜单策略、条目角色以及对齐标志替换为完全限定的成员名称，以获得更清晰的语义并提升工具支持。
- 在 API 和服务类中收紧可选 logger 参数的类型注解，显式使用 `Optional[logging.Logger]` 类型。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提高可读性并增强对静态分析的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 UI 和核心模块中规范 Qt/PySide 枚举的使用方式和类型注解，以满足静态分析要求，同时让弹幕发送和历史记录处理行为与其数据模型保持一致。

Bug 修复：
- 当系统代理被禁用时，确保 HTTP 会话使用空的代理映射而不是 `None`，以避免类型不匹配。
- 使 `HistoryManager.verify_dmids` 在输入为空时返回 `0`，从而保证其公共 API 始终返回整数。
- 将弹幕发送错误处理逻辑与 `Danmaku` 和 `DanmakuSendResult` 数据模型对齐，修复属性名与字段名不一致的问题。

功能增强：
- 用全限定名称替换 Qt/PySide 的简写枚举、标志、光标形状、边框形状、缩放模式、上下文菜单策略、条目角色和对齐标志，以获得更清晰的语义和更好的工具支持。
- 在 API 和服务类中收紧可选日志记录器参数类型，将其显式标注为 `logging.Logger | None`。
- 在 UI 代码中使用更具体的 `QTextCursor` 和 `QMessageBox` 枚举成员，以提升可读性并改善与静态类型检查的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize Qt/PySide enum usages and type annotations across UI and core modules to satisfy static analysis while aligning danmaku sending and history handling behavior with their data models.

Bug Fixes:
- Ensure HTTP sessions use an empty proxy mapping instead of None when system proxies are disabled to avoid type mismatches.
- Make HistoryManager.verify_dmids return 0 for empty input so its public API consistently returns an integer.
- Align danmaku send error handling with the Danmaku and DanmakuSendResult data models, fixing attribute and field name mismatches.

Enhancements:
- Replace shorthand Qt/PySide enums, flags, cursor shapes, frame shapes, resize modes, context menu policies, item roles, and alignment flags with fully qualified members for clearer semantics and better tooling support.
- Tighten optional logger parameters in API and service classes by annotating them explicitly as logging.Logger | None.
- Use more specific QTextCursor and QMessageBox enum members in UI code to improve readability and static type checking compatibility.

</details>

</details>

</details>