### PR TITLE
fix(ui): 修复监视器长文本导致窗口无法缩小的 Bug

### DIFF
--- a/src/danmaku_sender/ui/monitor_tab.py
+++ b/src/danmaku_sender/ui/monitor_tab.py
@@ -3,7 +3,7 @@ import threading
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QGroupBox, QTextEdit, 
-    QPushButton, QSpinBox, QMessageBox, QGridLayout
+    QPushButton, QSpinBox, QMessageBox, QGridLayout, QSizePolicy
 )
 from PySide6.QtGui import QTextCursor
 from PySide6.QtCore import Qt
@@ -41,8 +41,12 @@ class MonitorTab(QWidget):
             color: #34495e;
             padding: 2px 0px;
         """)
+        self.target_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        self.target_label.setMinimumWidth(0)
+        line_height = self.target_label.fontMetrics().lineSpacing()
+        self.target_label.setMaximumHeight(line_height * 3 + 10)
+
         self.target_label.setWordWrap(True)
-        self.target_label.setMaximumHeight(70)
         self.target_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
         info_layout.addWidget(QLabel("当前目标:"))


### PR DESCRIPTION
- 开启 target_label 的 setWordWrap(True)，解除对水平最小宽度的布局锁定。
- 优化 target_label 的显示逻辑，展示完整的视频标题和分P名称。
- 修复了 #174 描述的 UI 布局僵死问题。

## 由 Sourcery 提供的摘要

改进监视器选项卡中目标标签的布局，以在不影响窗口缩放的前提下处理较长的视频标题，并更清晰地展示目标信息。

错误修复：
- 通过为目标标签启用自动换行并放宽长文本时的布局约束，使监视器窗口在缩小时能够正常工作。

增强功能：
- 在监视器目标标签中以多行布局显示完整的视频标题和分段名称，并调整内边距和对齐方式，同时在工具提示中镜像显示这些文本以提高可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进监视器标签中的目标标签，以在保持窗口可调整大小的同时更好地处理较长的视频标题。

Bug Fixes:
- 修复当目标文本过长导致无法将窗口缩小、从而使监视器窗口布局冻结的问题。

Enhancements:
- 在监视器目标标签中以多行布局显示完整视频标题和分段名称，并通过调整样式及同步显示的工具提示来提高可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the monitor tab target label to better handle long video titles while keeping the window resizable.

Bug Fixes:
- Fix monitor window layout freezing when long target text prevented the window from being resized smaller.

Enhancements:
- Show full video title and part name in the monitor target label using a multi-line layout with adjusted styling and tooltip mirroring for readability.

</details>

</details>

Bug 修复：
- 通过在目标标签上启用自动换行并移除长文本导致的布局约束，使监视器窗口能够正确缩小。

增强功能：
- 在监视器目标标签中显示完整的视频标题和分集名称，使用更清晰的多行布局并调整内边距，从而提升可读性。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

改进监视器选项卡中目标标签的布局，以在不影响窗口缩放的前提下处理较长的视频标题，并更清晰地展示目标信息。

错误修复：
- 通过为目标标签启用自动换行并放宽长文本时的布局约束，使监视器窗口在缩小时能够正常工作。

增强功能：
- 在监视器目标标签中以多行布局显示完整的视频标题和分段名称，并调整内边距和对齐方式，同时在工具提示中镜像显示这些文本以提高可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进监视器标签中的目标标签，以在保持窗口可调整大小的同时更好地处理较长的视频标题。

Bug Fixes:
- 修复当目标文本过长导致无法将窗口缩小、从而使监视器窗口布局冻结的问题。

Enhancements:
- 在监视器目标标签中以多行布局显示完整视频标题和分段名称，并通过调整样式及同步显示的工具提示来提高可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the monitor tab target label to better handle long video titles while keeping the window resizable.

Bug Fixes:
- Fix monitor window layout freezing when long target text prevented the window from being resized smaller.

Enhancements:
- Show full video title and part name in the monitor target label using a multi-line layout with adjusted styling and tooltip mirroring for readability.

</details>

</details>

</details>