### PR TITLE
refactor(editor): 语义化重构：将校验器相关组件更名为编辑器

### DIFF
--- a/src/danmaku_sender/core/editor_session.py
+++ b/src/danmaku_sender/core/editor_session.py
@@ -13,14 +13,14 @@ class ChangedRecord(TypedDict):
     old_value: Any
 
 
-class ValidatorSession:
+class EditorSession:
     """
     校验器逻辑会话层。
     负责管理数据快照、执行修改逻辑、维护脏状态及撤销栈。
     """
     def __init__(self, state: AppState):
         self.state = state
-        self.logger = logging.getLogger("ValidatorSession")
+        self.logger = logging.getLogger("EditorSession")
         
         self.original_snapshot: list[Danmaku] = []          # 原始数据的深拷贝
         self.current_issues: list[dict[str, Any]] = []   # 当前的问题列表
@@ -28,7 +28,7 @@ class ValidatorSession:
 
     @property
     def is_dirty(self) -> bool:
-        return self.state.validator_is_dirty
+        return self.state.editor_is_dirty
     
     @property
     def has_active_session(self) -> bool:
@@ -39,7 +39,7 @@ class ValidatorSession:
         return bool(self.undo_stack)
 
     def set_dirty(self, dirty: bool):
-        self.state.validator_is_dirty = dirty
+        self.state.editor_is_dirty = dirty
 
     def load_and_validate(self) -> bool:
         """加载数据并执行校验"""
@@ -58,7 +58,7 @@ class ValidatorSession:
         self.logger.info(f"启动校验会话... 原始弹幕总数: {len(self.original_snapshot)}")
         
         # 执行校验
-        raw_issues: list[ValidationIssue] = validate_danmaku_list(self.original_snapshot, duration_ms, self.state.validator_config)
+        raw_issues: list[ValidationIssue] = validate_danmaku_list(self.original_snapshot, duration_ms, self.state.validation_config)
         
         # 转换结构
         self.current_issues = []

--- a/src/danmaku_sender/core/services/danmaku_validator.py
+++ b/src/danmaku_sender/core/services/danmaku_validator.py
@@ -1,7 +1,7 @@
 from typing import TypedDict
 
 from ..models.danmaku import Danmaku
-from ..state import ValidatorConfig
+from ..state import ValidationConfig
 
 
 FORBIDDEN_SYMBOLS = "☢⚠☣☠⚡💣⚔🔥"
@@ -16,7 +16,7 @@ class ValidationIssue(TypedDict):
 def validate_danmaku_list(
         danmaku_list: list[Danmaku],
         video_duration_ms: int = -1,
-        validator_config: ValidatorConfig | None = None
+        validation_config: ValidationConfig | None = None
     ) -> list[ValidationIssue]:
     """
     校验弹幕列表，找出不符合B站发送规则的弹幕。
@@ -27,8 +27,8 @@ def validate_danmaku_list(
         list: 一个包含问题弹幕信息的字典列表。
     """
     # 提取用户规则
-    custom_enabled = validator_config.enabled if validator_config else False
-    keywords = validator_config.blocked_keywords if validator_config else []
+    custom_enabled = validation_config.enabled if validation_config else False
+    keywords = validation_config.blocked_keywords if validation_config else []
 
     problems: list[ValidationIssue] = []
     for i, dm in enumerate(danmaku_list):

--- a/src/danmaku_sender/core/state.py
+++ b/src/danmaku_sender/core/state.py
@@ -75,8 +75,8 @@ class MonitorConfig:
 
 
 @dataclass
-class ValidatorConfig:
-    """校验器的配置数据"""
+class ValidationConfig:
+    """校验规则"""
     # 用户自定义规则
     enabled: bool = True
     blocked_keywords: list[str] = field(default_factory=list)
@@ -133,13 +133,13 @@ class AppState(QObject):
         # 各模块配置
         self.sender_config = SenderConfig()
         self.monitor_config = MonitorConfig()
-        self.validator_config = ValidatorConfig()
+        self.validation_config = ValidationConfig() 
 
         # 运行时状态
         self.video_state = VideoState()
 
-        # True 表示校验器有未应用的修改，SenderTab 拦截发送
-        self.validator_is_dirty: bool = False
+        # True 表示编辑器有未应用的修改，SenderTab 拦截发送
+        self.editor_is_dirty: bool = False
 
     def update_credentials(self, sessdata: str, bili_jct: str):
         """更新凭证并通知监听者"""

--- a/src/danmaku_sender/ui/editor_tab.py
+++ b/src/danmaku_sender/ui/editor_tab.py
@@ -10,16 +10,16 @@ from PySide6.QtCore import Qt
 from .dialogs import EditDanmakuDialog
 
 from ..core.state import AppState
-from ..core.validator_session import ValidatorSession
+from ..core.editor_session import EditorSession
 from ..utils.time_utils import format_ms_to_hhmmss
 
 
-class ValidatorTab(QWidget):
+class EditorTab(QWidget):
     def __init__(self):
         super().__init__()
         self._state: AppState | None = None
-        self.session: ValidatorSession | None = None
-        self.logger = logging.getLogger("ValidatorTab")
+        self.session: EditorSession | None = None
+        self.logger = logging.getLogger("EditorTab")
 
         self._create_ui()
 
@@ -153,20 +153,20 @@ class ValidatorTab(QWidget):
             self._disconnect_signals()
 
         self._state = state
-        self.session = ValidatorSession(state)
+        self.session = EditorSession(state)
 
-        cfg = state.validator_config
+        validation_cfg = state.validation_config
 
         # 初始化 UI 值
         self.enable_custom_checkbox.blockSignals(True)
-        self.enable_custom_checkbox.setChecked(cfg.enabled)
+        self.enable_custom_checkbox.setChecked(validation_cfg.enabled)
         self.enable_custom_checkbox.blockSignals(False)
 
         self.keywords_input.blockSignals(True)
-        self.keywords_input.setText(", ".join(cfg.blocked_keywords))
+        self.keywords_input.setText(", ".join(validation_cfg.blocked_keywords))
         self.keywords_input.blockSignals(False)
 
-        self.keywords_input.setEnabled(cfg.enabled)
+        self.keywords_input.setEnabled(validation_cfg.enabled)
 
         # 重新连接信号
         self.enable_custom_checkbox.stateChanged.connect(self._on_toggle_custom)
@@ -200,7 +200,7 @@ class ValidatorTab(QWidget):
             return
 
         is_on = self.enable_custom_checkbox.isChecked()
-        self._state.validator_config.enabled = is_on
+        self._state.validation_config.enabled = is_on
         self.keywords_input.setEnabled(is_on)
 
     def _on_keywords_changed(self, text):
@@ -212,7 +212,7 @@ class ValidatorTab(QWidget):
         parts = [k.strip() for k in raw_text.split(',') if k.strip()]
         unique_keywords = sorted(list(set(parts)))
 
-        self._state.validator_config.blocked_keywords = unique_keywords
+        self._state.validation_config.blocked_keywords = unique_keywords
 
     def _update_ui_state(self):
         """更新 UI 状态"""
@@ -267,7 +267,7 @@ class ValidatorTab(QWidget):
 
         # 检查未保存修改
         if self.session.is_dirty:
-            reply = QMessageBox.question(self, "确认", "当前有未应用的修改，重新验证将丢弃这些修改。\n是否继续？", QMessageBox.Yes | QMessageBox.No)
+            reply = QMessageBox.question(self, "确认", "当前有未应用的修改，重新验证将丢弃这些修改。\n是否继续？", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
             if reply == QMessageBox.StandardButton.No:
                 return
             

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import QUrl, QTimer
 from .sender_tab import SenderTab
 from .settings_tab import SettingsTab
 from .monitor_tab import MonitorTab
-from .validator_tab import ValidatorTab
+from .editor_tab import EditorTab
 from .dialogs import AboutDialog, HelpDialog, UpdateDialog
 from .history_tab import HistoryTab
 
@@ -58,14 +58,14 @@ class MainWindow(QMainWindow):
     def init_tabs(self):
         self.tab_settings = SettingsTab()
         self.tab_sender = SenderTab()
-        self.tab_validator = ValidatorTab()
+        self.tab_editor = EditorTab()
         self.tab_monitor = MonitorTab()
         self.tab_history = HistoryTab()
 
         # 添加至选项卡
         self.tabs.addTab(self.tab_settings, "全局设置")
         self.tabs.addTab(self.tab_sender, "弹幕发射器")
-        self.tabs.addTab(self.tab_validator, "弹幕校验器")
+        self.tabs.addTab(self.tab_editor, "弹幕校验器")
         self.tabs.addTab(self.tab_monitor, "弹幕监视器")
         self.tabs.addTab(self.tab_history, "弹幕历史记录")
 
@@ -146,7 +146,7 @@ class MainWindow(QMainWindow):
         # 页面数据绑定
         self.tab_settings.bind_state(self.state)
         self.tab_sender.bind_state(self.state)
-        self.tab_validator.bind_state(self.state)
+        self.tab_editor.bind_state(self.state)
         self.tab_monitor.bind_state(self.state)
         self.tab_history.bind_state(self.state)
 

--- a/src/danmaku_sender/ui/sender_tab.py
+++ b/src/danmaku_sender/ui/sender_tab.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import Qt, QDateTime
 from ..core.models.video import VideoInfo
 from ..core.services.danmaku_exporter import create_xml_from_danmakus
 from ..core.services.danmaku_parser import DanmakuParser
+from ..core.state import AppState
 from ..core.workers import FetchInfoWorker, SendTaskWorker
 from ..utils.string_utils import parse_bilibili_link
 from ..utils.time_utils import format_seconds_to_duration
@@ -22,7 +23,7 @@ from ..utils.time_utils import format_seconds_to_duration
 class SenderTab(QWidget):
     def __init__(self):
         super().__init__()
-        self._state = None
+        self._state: AppState | None = None
         self.logger = logging.getLogger("SenderTab")
         self.stop_event = threading.Event()
         self.danmaku_parser = DanmakuParser()
@@ -453,7 +454,7 @@ class SenderTab(QWidget):
         # 校验
         state = self._state
 
-        if state.validator_is_dirty:
+        if state.editor_is_dirty:
             QMessageBox.warning(
                 self, 
                 "存在未保存的修改", 

--- a/src/danmaku_sender/utils/config_manager.py
+++ b/src/danmaku_sender/utils/config_manager.py
@@ -19,7 +19,7 @@ def save_app_config(state: AppState):
     config_data = {
         "sender": state.sender_config.to_dict(),
         "monitor": state.monitor_config.to_dict(),
-        "validator": state.validator_config.to_dict()
+        "validation": state.validation_config.to_dict()
     }
 
     try:
@@ -46,7 +46,7 @@ def load_app_config(state: AppState):
         if "monitor" in data:
             state.monitor_config.from_dict(data["monitor"])
         if "validator" in data:
-            state.validator_config.from_dict(data["validator"])
+            state.validation_config.from_dict(data["validator"])
 
         logger.info("配置加载成功。")
     except Exception as e:


### PR DESCRIPTION
- 将 `ValidatorTab` 和 `ValidatorSession` 分别更名为 `EditorTab` 和 `EditorSession`
- 将 `ValidatorConfig` 重命名为 `ValidationConfig`，解耦 UI 归属与业务逻辑语义
- 同步更新 `AppState` 中的 `validator_is_dirty` 为 `editor_is_dirty`
- 此改动旨在为后续新增的预览 (#181) 及时间平移 (#183) 功能提供更准确的架构语境

## Summary by Sourcery

将弹幕验证的 UI 和会话层重命名为面向编辑器的命名方案，并相应更新相关的状态与配置绑定。

Enhancements:
- 在 UI 与核心层中，将验证器选项卡和会话类统一重命名为面向编辑器的等价名称，以更好地体现其角色。
- 将验证器配置和脏状态相关字段重命名为更中性的验证/编辑器术语，并将这些变更传播到状态管理、验证服务以及发送端保护逻辑中。
- 调整配置持久化时使用的键名，以采用新的验证配置命名，同时保持现有行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the danmaku validation UI and session layer to an editor-oriented naming scheme and update related state/config wiring accordingly.

Enhancements:
- Rename the validator tab and session classes to editor equivalents across UI and core layers to better reflect their role.
- Rename validator configuration and dirty-state fields to neutral validation/editor terminology and propagate these changes through state management, validation services, and sender safeguards.
- Adjust configuration persistence keys to use the new validation config naming while maintaining existing behavior.

</details>