### PR TITLE
fix(ci): 隔离文档构建环境，解决 Linux 下 winrt 编译失败问题

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           cache-dependency-path: "pyproject.toml"
 
       - name: Install Dependencies
-        run: pip install .[docs]
+        run: pip install mkdocs-material
 
       - name: Deploy
         run: mkdocs gh-deploy --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "requests>=2.32.5",
     "platformdirs>=4.5.1",
     "keyring>=25.7.0",
-    "win11toast>=0.36.2",
+    "win11toast>=0.36.2; sys_platform == 'win32'",
     "cryptography>=46.0.3",
     "peewee>=4.0.1",
 ]


### PR DESCRIPTION
1. 修改 GitHub Actions 流程，由安装整个项目改为仅安装文档构建所需的 mkdocs 依赖。
2. 避免 CI 环境（Ubuntu）尝试安装 Windows 特有的 win11toast 库，提升构建稳定性。

## Summary by Sourcery

在 CI 中隔离文档构建依赖，以避免平台相关问题并提升文档部署的稳定性。

Build：
- 将 `win11toast` 标记为仅限 Windows 的依赖，防止其在非 Windows 平台上被安装。

CI：
- 更新文档 CI 工作流，仅安装 `mkdocs-material`，而不是带有 docs extras 的完整项目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate documentation build dependencies in CI to avoid platform-specific issues and improve docs deployment stability.

Build:
- Mark win11toast as a Windows-only dependency to prevent installation on non-Windows platforms.

CI:
- Update docs CI workflow to install only mkdocs-material instead of the full project with docs extras.

</details>