### PR TITLE
fix(api): 实现 WbiSigner 线程锁以修复竞态条件导致启动时冗余API请求

### DIFF
--- a/src/danmaku_sender/api/wbi_signer.py
+++ b/src/danmaku_sender/api/wbi_signer.py
@@ -58,15 +58,18 @@ class WbiSigner:
 
     @classmethod
     def get_wbi_keys(cls) -> tuple[str, str]:
-        """获取最新的 img_key 和 sub_key"""      
-        # 如果缓存存在且未过期，直接返回缓存的键值
+        """获取最新的 img_key 和 sub_key"""
+        # 锁外第一次检查
+        current_now = time.time()
         if (cls._cached_keys is not None
-            and time.time() - cls._cached_time < cls.CACHE_DURATION):
+            and current_now - cls._cached_time < cls.CACHE_DURATION):
             return cls._cached_keys
 
         with cls._lock:
+            now_inside_lock = time.time()
+            # 锁内第二次检查
             if (cls._cached_keys is not None
-                and time.time() - cls._cached_time < cls.CACHE_DURATION):
+                and now_inside_lock - cls._cached_time < cls.CACHE_DURATION):
                 return cls._cached_keys
 
             # 获取新的键值
@@ -85,7 +88,7 @@ class WbiSigner:
 
                 # 更新缓存
                 cls._cached_keys = (img_key, sub_key)
-                cls._cached_time = time.time()
+                cls._cached_time = now_inside_lock
 
                 logger.debug("WBI 密钥获取成功并已缓存。")
                 return cls._cached_keys


### PR DESCRIPTION
- 在 WbiSigner 类中引入 `threading.Lock` 机制。
- 采用“双重检查锁定 (Double-Checked Locking)”模式重构 `get_wbi_keys` 方法。
- 解决了程序启动时由于多个后台 Worker 同时初始化导致向 B 站发送重复鉴权请求的问题。
- 优化了高并发场景下的性能，确保全生命周期内仅在缓存失效时执行一次物理网络请求。

## Summary by Sourcery

在 WbiSigner 中同步 WBI 密钥的获取，以避免冗余的并发网络请求，并确保各个 worker 在访问时正确遵守缓存。

Bug 修复：
- 防止当多个 worker 并发初始化时，由竞态条件引发的重复 WBI 密钥获取请求。

增强：
- 在 WbiSigner 中引入类级别锁和双重检查的缓存访问机制，在高并发场景下串行化 WBI 密钥刷新流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize WBI key retrieval in WbiSigner to avoid redundant concurrent network requests and ensure cache-respected access across workers.

Bug Fixes:
- Prevent duplicate WBI key fetches caused by race conditions when multiple workers initialize concurrently.

Enhancements:
- Introduce a class-level lock and double-checked cache access in WbiSigner to serialize WBI key refreshes under high concurrency.

</details>

Bug 修复：
- 修复一个竞争条件问题：应用启动时多个 worker 可能会触发重复的 WBI 密钥获取请求。

增强：
- 使用类级别锁和双重检查的缓存机制来保护 WbiSigner 的密钥获取逻辑，在高并发场景下降低网络调用次数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在 WbiSigner 中同步 WBI 密钥的获取，以避免冗余的并发网络请求，并确保各个 worker 在访问时正确遵守缓存。

Bug 修复：
- 防止当多个 worker 并发初始化时，由竞态条件引发的重复 WBI 密钥获取请求。

增强：
- 在 WbiSigner 中引入类级别锁和双重检查的缓存访问机制，在高并发场景下串行化 WBI 密钥刷新流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize WBI key retrieval in WbiSigner to avoid redundant concurrent network requests and ensure cache-respected access across workers.

Bug Fixes:
- Prevent duplicate WBI key fetches caused by race conditions when multiple workers initialize concurrently.

Enhancements:
- Introduce a class-level lock and double-checked cache access in WbiSigner to serialize WBI key refreshes under high concurrency.

</details>

</details>