### PR TITLE
refactor(sender): 重构发送逻辑，解耦引擎实例并统一日志路由

### DIFF
--- a/src/danmaku_sender/ui/controllers/monitor_controller.py
+++ b/src/danmaku_sender/ui/controllers/monitor_controller.py
@@ -16,7 +16,6 @@ class MonitorController(QObject):
     statsUpdated = Signal(dict)
     statusUpdated = Signal(str)
     taskFinished = Signal()
-    messageLogged = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -41,7 +40,6 @@ class MonitorController(QObject):
         self._worker.statsUpdated.connect(self.statsUpdated.emit)
         self._worker.statusUpdated.connect(self.statusUpdated.emit)
         self._worker.taskFinished.connect(self._on_worker_finished)
-        self._worker.messageLogged.connect(self.messageLogged.emit)
 
         self._worker.finished.connect(self._on_worker_cleanup)
         self._worker.finished.connect(self._worker.deleteLater)

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -15,8 +15,7 @@ logger = logging.getLogger("App.System.SenderController")
 class SenderController(QObject):
     """发送任务业务控制器"""
     progressUpdated = Signal(int, int)
-    taskFinished = Signal(object)
-    messageLogged = Signal(str)
+    taskFinished = Signal(list)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -47,7 +46,6 @@ class SenderController(QObject):
 
         self._worker.progressUpdated.connect(self.progressUpdated.emit)
         self._worker.taskFinished.connect(self._on_worker_finished)
-        self._worker.messageLogged.connect(self.messageLogged.emit)
 
         self._worker.finished.connect(self._on_worker_cleanup)
         self._worker.finished.connect(self._worker.deleteLater)
@@ -69,10 +67,10 @@ class SenderController(QObject):
 
     # region Slots
 
-    @Slot(object)
-    def _on_worker_finished(self, scheduler_instance):
+    @Slot(list)
+    def _on_worker_finished(self, unsent_danmakus: list):
         """内部槽函数：处理任务结束清理并向上传递"""
-        self.taskFinished.emit(scheduler_instance)
+        self.taskFinished.emit(unsent_danmakus)
 
     @Slot()
     def _on_worker_cleanup(self):

--- a/src/danmaku_sender/ui/framework/concurrency.py
+++ b/src/danmaku_sender/ui/framework/concurrency.py
@@ -19,8 +19,6 @@ class BaseWorker(QThread):
     _keep_alive_registry = set()       # 静态注册表: 存放所有正在运行的任务，以防止被 GC
     _registry_lock = threading.Lock()  # 注册表线程锁
 
-    messageLogged = Signal(str)
-
     def __init__(self, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger("App.System.Worker.Base")
@@ -47,7 +45,6 @@ class BaseWorker(QThread):
     def report_error(self, title: str, exception: Exception):
         """统一的异常捕获与上报接口"""
         self.logger.error(f"{title}: {exception}", exc_info=True)
-        self.messageLogged.emit(f"{title}: {exception}")
 
 
 class WorkerSignals(QObject):

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -184,7 +184,6 @@ class MonitorPage(QWidget):
         self.monitor_controller.statsUpdated.connect(self._on_stats_updated)
         self.monitor_controller.statusUpdated.connect(self.status_label.setText)
         self.monitor_controller.taskFinished.connect(self._on_finished)
-        self.monitor_controller.messageLogged.connect(self.append_log)
 
     def bind_state(self, state: AppState):
         if self._state is state:

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -16,7 +16,7 @@ from .controllers.sender_controller import SenderController
 
 from ..core.models.video import VideoInfo
 from ..core.models.structs import VideoTarget
-from ..core.services.danmaku_exporter import create_xml_from_danmakus
+from ..core.services.danmaku_exporter import UnsentDanmakusRecord, create_xml_from_danmakus
 from ..core.services.danmaku_parser import DanmakuParser
 from ..core.state import AppState
 from ..utils.string_utils import parse_bilibili_link
@@ -89,12 +89,12 @@ class SenderPage(QWidget):
 
     def _connect_signals(self):
         # 子组件信号
-        self.basic_group.file_btn.clicked.connect(self.select_file)
-        self.basic_group.fetch_btn.clicked.connect(self.fetch_video_info)
+        self.basic_group.file_btn.clicked.connect(self._select_file)
+        self.basic_group.fetch_btn.clicked.connect(self._fetch_video_info)
         self.basic_group.part_combo.currentIndexChanged.connect(self._on_part_selected)
 
         # 本地信号
-        self.start_btn.clicked.connect(self.toggle_task)
+        self.start_btn.clicked.connect(self._toggle_task)
 
         # VideoController
         self.video_controller.fetchStarted.connect(self._on_fetch_started)
@@ -104,7 +104,6 @@ class SenderPage(QWidget):
         # SenderController
         self.sender_controller.progressUpdated.connect(self._on_send_progress)
         self.sender_controller.taskFinished.connect(self._on_send_finished)
-        self.sender_controller.messageLogged.connect(self.append_log)
 
     def bind_state(self, state: AppState):
         """将 UI 控件与 AppState 进行双向绑定"""
@@ -121,7 +120,10 @@ class SenderPage(QWidget):
         self.log_output.append(message)
         self.log_output.moveCursor(QTextCursor.MoveOperation.End)
 
-    def select_file(self):
+    # region Slots
+    # region Slots Internal
+    @Slot()
+    def _select_file(self):
         """文件选择逻辑"""
         if not self._state:
             return
@@ -144,7 +146,8 @@ class SenderPage(QWidget):
                 self.logger.error(f"❌ 解析失败: {e}")
                 QMessageBox.critical(self, "解析失败", str(e))
 
-    def fetch_video_info(self):
+    @Slot()
+    def _fetch_video_info(self):
         """UI 层: 负责获取参数，下发指令"""
         if not self._state:
             return
@@ -165,8 +168,80 @@ class SenderPage(QWidget):
 
         self.video_controller.fetch_info(bvid, self._state.get_api_auth())
 
+    @Slot(int)
+    def _on_part_selected(self, index: int):
+        """处理分P选择变化"""
+        if not self._state:
+            return
 
-    # region Slots
+        if index < 0:
+            return
+
+        data = self.basic_group.part_combo.itemData(index)
+        if not data or not isinstance(data, dict):
+            return
+
+        cid = data['cid']
+        duration = data['duration']
+        part_name = self.basic_group.part_combo.currentText()
+
+        self._state.video_state.selected_cid = cid
+        self._state.video_state.selected_part_duration_ms = duration * 1000
+        self._state.video_state.selected_part_name = part_name
+        self.logger.info(f"已选择分P: {part_name} (CID: {cid})")
+
+    @Slot()
+    def _toggle_task(self):
+        """开始/停止 任务"""
+        if not self._state:
+            return
+
+        # 如果正在运行 -> 停止
+        if self.sender_controller.is_running():
+            self.sender_controller.stop_task()
+            self.start_btn.setEnabled(False)
+            self.start_btn.setText("停止中...")
+            self.logger.info("发送器：正在请求中止...")
+            self.progress_bar.setFormat("%p% (正在停止...)")
+            return
+
+        # 如果未运行 -> 开始
+        # 校验
+        state = self._state
+
+        if state.editor_is_dirty:
+            QMessageBox.warning(
+                self,
+                "存在未保存的修改",
+                "检测到【弹幕校验器】中有未应用的修改！\n\n请先返回校验器点击“应用所有修改”，\n否则发送的将是旧的、未修复的弹幕。"
+            )
+            return
+
+        if not state.video_state.is_ready_to_send:
+            QMessageBox.warning(self, "条件不足", "请确保 BV号、分P、弹幕文件 均已就绪。")
+            return
+
+        if not state.sessdata or not state.bili_jct:
+            QMessageBox.warning(self, "凭证缺失", "请先在【全局设置】页填入 SESSDATA 和 BILI_JCT。")
+            return
+
+        # UI 锁定
+        self._set_ui_for_task_start()
+
+        # 构造配置
+        target = VideoTarget(
+            bvid=state.video_state.bvid,
+            cid=state.video_state.selected_cid,
+            title=state.video_state.video_title
+        )
+        auth_config = state.get_api_auth()
+        strategy_config = state.sender_config
+
+        # 启动线程
+        self.sender_controller.start_task(target, state.video_state.loaded_danmakus, auth_config, strategy_config)
+
+    # endregion
+    # region Slots VideoController
 
     @Slot()
     def _on_fetch_started(self):
@@ -226,77 +301,7 @@ class SenderPage(QWidget):
         QMessageBox.warning(self, "获取失败", f"无法获取视频信息:\n{err_msg}")
 
     # endregion
-
-    @Slot(int)
-    def _on_part_selected(self, index: int):
-        """处理分P选择变化"""
-        if not self._state:
-            return
-
-        if index < 0:
-            return
-
-        data = self.basic_group.part_combo.itemData(index)
-        if not data or not isinstance(data, dict):
-            return
-
-        cid = data['cid']
-        duration = data['duration']
-        part_name = self.basic_group.part_combo.currentText()
-
-        self._state.video_state.selected_cid = cid
-        self._state.video_state.selected_part_duration_ms = duration * 1000
-        self._state.video_state.selected_part_name = part_name
-        self.logger.info(f"已选择分P: {part_name} (CID: {cid})")
-
-    def toggle_task(self):
-        """开始/停止 任务"""
-        if not self._state:
-            return
-
-        # 如果正在运行 -> 停止
-        if self.sender_controller.is_running():
-            self.sender_controller.stop_task()
-            self.start_btn.setEnabled(False)
-            self.start_btn.setText("停止中...")
-            self.logger.info("发送器：正在请求中止...")
-            self.progress_bar.setFormat("%p% (正在停止...)")
-            return
-
-        # 如果未运行 -> 开始
-        # 校验
-        state = self._state
-
-        if state.editor_is_dirty:
-            QMessageBox.warning(
-                self,
-                "存在未保存的修改",
-                "检测到【弹幕校验器】中有未应用的修改！\n\n请先返回校验器点击“应用所有修改”，\n否则发送的将是旧的、未修复的弹幕。"
-            )
-            return
-
-        if not state.video_state.is_ready_to_send:
-            QMessageBox.warning(self, "条件不足", "请确保 BV号、分P、弹幕文件 均已就绪。")
-            return
-
-        if not state.sessdata or not state.bili_jct:
-            QMessageBox.warning(self, "凭证缺失", "请先在【全局设置】页填入 SESSDATA 和 BILI_JCT。")
-            return
-
-        # UI 锁定
-        self._set_ui_for_task_start()
-
-        # 构造配置
-        target = VideoTarget(
-            bvid=state.video_state.bvid,
-            cid=state.video_state.selected_cid,
-            title=state.video_state.video_title
-        )
-        auth_config = state.get_api_auth()
-        strategy_config = state.sender_config
-
-        # 启动线程
-        self.sender_controller.start_task(target, state.video_state.loaded_danmakus, auth_config, strategy_config)
+    # region Slots SenderController
 
     @Slot(int, int)
     def _on_send_progress(self, attempted: int, total: int):
@@ -317,6 +322,26 @@ class SenderPage(QWidget):
                 self.progress_bar.setFormat("%p%")
 
         self.status_label.setText(f"发送中: {attempted}/{total}")
+
+    @Slot(list)
+    def _on_send_finished(self, unsent_danmakus: list[UnsentDanmakusRecord]):
+        """任务结束后的清理与保存逻辑"""
+        # 恢复 UI
+        self._reset_ui_after_task()
+
+        if self.sender_controller.is_stopped_manually():
+            self.status_label.setText("发送器：任务中止")
+            self.progress_bar.setFormat("%p% (已停止)")
+        else:
+            self.status_label.setText("发送器：任务结束")
+            self.progress_bar.setFormat("%p% (已完成)")
+
+        # 检查是否有失败弹幕
+        if unsent_danmakus:
+            self._prompt_save_unsent_xml(unsent_danmakus)
+
+    # endregion
+    # endregion
 
     def _calculate_eta_seconds(self, attempted: int, total: int) -> float:
         """从状态中提取配置，并调用纯数学方法计算 ETA"""
@@ -367,54 +392,24 @@ class SenderPage(QWidget):
 
         return (normal_count * avg_normal) + (rest_count * avg_rest)
 
-    def _on_send_finished(self, sender_instance):
-        """任务结束后的清理与保存逻辑"""
-        # 恢复 UI
-        self._reset_ui_after_task()
-
-        if self.sender_controller.is_stopped_manually():
-            self.status_label.setText("发送器：任务中止")
-            self.progress_bar.setFormat("%p% (已停止)")
-        else:
-            self.status_label.setText("发送器：任务结束")
-            self.progress_bar.setFormat("%p% (已完成)")
-
-        # 检查是否有失败弹幕
-        if sender_instance and sender_instance.unsent_danmakus:
-            count = len(sender_instance.unsent_danmakus)
-            reply = QMessageBox.question(
-                self, "保存失败弹幕",
-                f"有 {count} 条弹幕发送失败。\n是否保存为新的 XML 文件以便重新发送？",
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-            )
-            if reply == QMessageBox.StandardButton.Yes:
-                file_path, _ = QFileDialog.getSaveFileName(self, "保存XML", "unsent.xml", "XML Files (*.xml)")
-                if file_path:
-                    try:
-                        create_xml_from_danmakus(sender_instance.unsent_danmakus, file_path)
-                        self.logger.info(f"未发送弹幕已保存至: {file_path}")
-                        QMessageBox.information(self, "保存成功", f"文件已保存至：\n{file_path}")
-                    except Exception as e:
-                        self.logger.error(f"保存XML文件失败: {e}")
-                        QMessageBox.critical(self, "保存失败", f"无法写入文件，请检查权限或路径。\n错误信息: {e}")
-
-    def _update_btn_style(self, running: bool):
-        """统一刷新按钮状态与图标的私有方法"""
-        state = "running" if running else "ready"
-        self.start_btn.setProperty("state", state)
-        self.start_btn.style().unpolish(self.start_btn)
-        self.start_btn.style().polish(self.start_btn)
-        self.start_btn.setIcon(self._icon_stop if running else self._icon_start)
-
-    def _set_inputs_locked(self, locked: bool):
-        """
-        设置输入控件的锁定状态
-
-        Args:
-            locked (bool): True 表示锁定(不可编辑)，False 表示解锁(可编辑)。
-        """
-        self.basic_group.set_inputs_locked(locked)
-        self.strategy_tabs.set_inputs_locked(locked)
+    def _prompt_save_unsent_xml(self, unsent_danmakus: list[UnsentDanmakusRecord]):
+        """询问并保存失败的弹幕到 XML"""
+        count = len(unsent_danmakus)
+        reply = QMessageBox.question(
+            self, "保存失败弹幕",
+            f"有 {count} 条弹幕发送失败。\n是否保存为新的 XML 文件以便重新发送？",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            file_path, _ = QFileDialog.getSaveFileName(self, "保存XML", "unsent.xml", "XML Files (*.xml)")
+            if file_path:
+                try:
+                    create_xml_from_danmakus(unsent_danmakus, file_path)
+                    self.logger.info(f"未发送弹幕已保存至: {file_path}")
+                    QMessageBox.information(self, "保存成功", f"文件已保存至：\n{file_path}")
+                except Exception as e:
+                    self.logger.error(f"保存XML文件失败: {e}")
+                    QMessageBox.critical(self, "保存失败", f"无法写入文件，请检查权限或路径。\n错误信息: {e}")
 
 
     # region UI State Management
@@ -454,6 +449,24 @@ class SenderPage(QWidget):
         self.progress_bar.setFormat("%p%")
 
     # endregion
+
+    def _update_btn_style(self, running: bool):
+        """统一刷新按钮状态与图标的私有方法"""
+        state = "running" if running else "ready"
+        self.start_btn.setProperty("state", state)
+        self.start_btn.style().unpolish(self.start_btn)
+        self.start_btn.style().polish(self.start_btn)
+        self.start_btn.setIcon(self._icon_stop if running else self._icon_start)
+
+    def _set_inputs_locked(self, locked: bool):
+        """
+        设置输入控件的锁定状态
+
+        Args:
+            locked (bool): True 表示锁定(不可编辑)，False 表示解锁(可编辑)。
+        """
+        self.basic_group.set_inputs_locked(locked)
+        self.strategy_tabs.set_inputs_locked(locked)
 
 
 class BasicParamsGroup(QGroupBox):

--- a/src/danmaku_sender/ui/workers.py
+++ b/src/danmaku_sender/ui/workers.py
@@ -20,7 +20,7 @@ from ..utils.notification_utils import send_windows_notification
 class SendTaskWorker(BaseWorker):
     """用于后台发送弹幕的线程"""
     progressUpdated = Signal(int, int)  # 已尝试, 总数
-    taskFinished = Signal(object)       # 携带 sender 实例以便后续处理(如保存失败弹幕)
+    taskFinished = Signal(list)         # 失败弹幕
 
     def __init__(
         self,
@@ -74,7 +74,8 @@ class SendTaskWorker(BaseWorker):
         finally:
             if ctx:
                 self._log_and_notify_summary(ctx)
-            self.taskFinished.emit(self.scheduler)
+            unsent = self.scheduler.unsent_danmakus if self.scheduler else []
+            self.taskFinished.emit(unsent)
 
     def _log_and_notify_summary(self, ctx: SendingContext):
         """记录日志并弹送系统通知（纯 UI 侧交互）"""
@@ -158,7 +159,7 @@ class MonitorTaskWorker(BaseWorker):
                         if stats.get('lost', 0) > 0:
                             msg += f" | ❌丢失:{stats['lost']}"
 
-                        self.messageLogged.emit(msg)
+                        self.logger.info(msg)
 
                         if self.stop_event.wait(snap_interval):
                             self.logger.info("收到停止信号，监视任务终止。")


### PR DESCRIPTION
- 移除 Worker 和 Controller 中冗余的 `messageLogged` 信号，统一走标准日志系统
- 隔离 `SendTaskWorker` 与 UI 的耦合，不再向外泄露 `Scheduler` 实例
- 瘦身 `SenderPage` 槽函数逻辑，将 XML 保存逻辑抽离至独立方法
- 清理无效的信号连接，优化内部槽函数命名规范

## Summary by Sourcery

重构弹幕发送器的 UI 和线程流程，以将 worker 与 UI 解耦、简化任务完成处理逻辑，并通过标准日志系统而不是自定义的 Qt 信号来路由日志信息。

Enhancements:
- 重命名并限定发送页的槽函数方法作用域，以明确内部回调与由控制器驱动的回调之间的区别，并改进信号组织结构。
- 更改发送任务完成管线，使 worker、控制器和 UI 之间只传递未发送的弹幕记录，而不是暴露调度器实例。
- 将提示用户及将未发送弹幕保存为 XML 的逻辑提取到发送页上的一个专用辅助工具中。
- 从 worker、控制器和页面中移除自定义的 `messageLogged` 信号，改为使用共享的 logger 来处理状态消息。
- 重新排序并重新分组发送页中的槽区域，更好地反映其在基础 UI、视频控制器事件和发送控制器事件方面的职责划分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the danmaku sender UI and threading flow to decouple workers from UI, simplify task completion handling, and route logging through the standard logging system instead of custom Qt signals.

Enhancements:
- Rename and scope sender page slot methods to clarify internal vs controller-driven callbacks and improve signal organization.
- Change the send-task completion pipeline to pass only unsent danmaku records between worker, controller, and UI instead of exposing the scheduler instance.
- Extract the logic for prompting and saving unsent danmakus to XML into a dedicated helper on the sender page.
- Remove custom messageLogged signals from workers, controllers, and pages in favor of using the shared logger for status messages.
- Reorder and regroup slot regions in the sender page to better reflect responsibilities for basic UI, video controller events, and sender controller events.

</details>