### PR TITLE
perf(video): 重构视频信息获取逻辑，支持批量获取并优化接口

### DIFF
--- a/src/danmaku_sender/ui/controllers/video_controller.py
+++ b/src/danmaku_sender/ui/controllers/video_controller.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable
 
 from PySide6.QtCore import QObject, Signal, QThreadPool, Slot
 
@@ -19,11 +20,30 @@ _bg_fetch_pool.setMaxThreadCount(1)
 _bg_fetch_pool.setObjectName("BackgroundVideoFetchPool")
 
 
-def _fetch_video_info(bvid: str, auth_config: ApiAuthConfig) -> VideoInfo:
-    """业务函数: 获取视频信息"""
+def _fetch_single_video_info(bvid: str, auth_config: ApiAuthConfig) -> VideoInfo:
+    """获取单个视频的详细信息"""
     with BiliApiClient.from_config(auth_config) as client:
         service = VideoFetcher(client)
         return service.fetch_info(bvid)
+
+def _fetch_multiple_video_infos(
+    bvids: list[str],
+    auth_config: ApiAuthConfig,
+    on_succeeded: Callable[[str, VideoInfo], None],
+    on_failed: Callable[[str, str], None]
+):
+    """
+    复用底层连接 (Keep-Alive) 获取多个视频信息。
+    通过回调函数实现结果的流式输出
+    """
+    with BiliApiClient.from_config(auth_config) as client:
+        service = VideoFetcher(client)
+        for bvid in bvids:
+            try:
+                info = service.fetch_info(bvid)
+                on_succeeded(bvid, info)
+            except Exception as e:
+                on_failed(bvid, str(e))
 
 
 class VideoController(QObject):
@@ -39,9 +59,9 @@ class VideoController(QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-    def fetch_info(self, bvid: str, auth_config: ApiAuthConfig, is_background: bool = False):
+    def fetch_single_info(self, bvid: str, auth_config: ApiAuthConfig, is_background: bool = False):
         """
-        获取视频信息
+        获取单条视频信息
 
         Args:
             bvid (str): 视频的 BV 号标识符。
@@ -57,7 +77,7 @@ class VideoController(QObject):
         if not is_background:
             self.fetchStarted.emit()
 
-        task = GenericTask(_fetch_video_info, bvid, auth_config)
+        task = GenericTask(_fetch_single_video_info, bvid, auth_config)
 
         @Slot(object)
         def _on_fetch_succeeded(info: VideoInfo):
@@ -74,3 +94,22 @@ class VideoController(QObject):
             _bg_fetch_pool.start(task)
         else:
             QThreadPool.globalInstance().start(task)
+
+    def fetch_multiple_infos(self, bvids: list[str], auth_config: ApiAuthConfig):
+        """
+        静默获取多条视频信息 (流式返回)
+
+        调用此方法会自动进入后台专有队列，且享有 HTTP Keep-Alive 性能加成。
+        """
+        if not bvids:
+            return
+
+        task = GenericTask(
+            _fetch_multiple_video_infos,
+            bvids,
+            auth_config,
+            self.fetchSucceeded.emit,
+            self.fetchFailed.emit
+        )
+
+        _bg_fetch_pool.start(task)

--- a/src/danmaku_sender/ui/history_page.py
+++ b/src/danmaku_sender/ui/history_page.py
@@ -311,13 +311,16 @@ class HistoryPage(QWidget):
             return
 
         auth_config = self._state.get_api_auth()
+        missing_bvids = []
         for row in records:
             bvid = row['bvid']
             if self._model.get_video_info(bvid) is None and bvid not in self._fetched_bvids:
                 self._fetched_bvids.add(bvid)
                 self._model.mark_as_loading(bvid)
-                # 下发给 Controller 排队
-                self.video_controller.fetch_info(bvid, auth_config, is_background=True)
+                missing_bvids.append(bvid)
+
+        if missing_bvids:
+            self.video_controller.fetch_multiple_infos(missing_bvids, auth_config)
 
     def _show_detail_dialog(self, record):
         video_info = self._model.get_video_info(record['bvid'])

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -169,7 +169,7 @@ class SenderPage(QWidget):
         self.basic_group.bv_input.setText(bvid)
         self._pending_part_index = p_index
 
-        self.video_controller.fetch_info(bvid, self._state.get_api_auth())
+        self.video_controller.fetch_single_info(bvid, self._state.get_api_auth())
 
     @Slot(int)
     def _on_part_selected(self, index: int):


### PR DESCRIPTION
## Summary by Sourcery

重构视频信息获取逻辑，以支持在复用连接的前提下进行批量获取，并更新调用方以使用新的单个和批量获取 API。

新功能：
- 在控制器中新增方法，用于在后台静默获取多个视频信息，支持流式回调以及 HTTP keep-alive 连接复用。

增强改进：
- 在控制器中重命名并澄清单视频获取方法，以便将其与新的批量 API 区分开来。
- 优化历史页面的元数据加载逻辑，改为对缺失的视频信息执行批量请求，而不是逐个发送获取请求。
- 更新发送方页面以使用重命名后的单视频获取方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor video info fetching to support batch retrieval with connection reuse and update callers to use the new single and multiple fetch APIs.

New Features:
- Add a controller method to silently fetch multiple video infos in the background with streaming callbacks and HTTP keep-alive reuse.

Enhancements:
- Rename and clarify the single-video fetch method in the controller to distinguish it from the new batch API.
- Optimize history page metadata loading to batch-miss video info requests instead of issuing individual fetches.
- Update sender page to use the renamed single-video fetch method.

</details>