### PR TITLE
ci: 更新 Windows 发布工作流，支持版本化的 ZIP、EXE 和安装包

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,25 +23,26 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[build]
 
-    - name: Process Version String
+    - name: Parse Version Strings
       id: version
       shell: pwsh
       run: |
+        # 从 Tag 获取版本号
         $tagName = "${{ github.ref_name }}"
-        $cleanVersion = $tagName.TrimStart('v')
+        $cleanVersion = $tagName -replace '^v', ''
 
-        # 处理成 Windows 强制要求的 4 位数字: 2.4.0.0
+        # 补齐四位数字给 Windows 资源属性用
         $parts = $cleanVersion.Split('.')
         while ($parts.Count -lt 4) { $parts += "0" }
-        $fourDigitVersion = $parts -join "."
+        $fourDigitVersion = $parts[0..3] -join "."
 
         echo "tag_name=$tagName" >> $env:GITHUB_OUTPUT
         echo "clean_version=$cleanVersion" >> $env:GITHUB_OUTPUT
         echo "four_digit=$fourDigitVersion" >> $env:GITHUB_OUTPUT
 
-    - name: Build EXE with Nuitka
+    - name: Build Standalone (For ZIP & Installer)
       run: |
-        python -m nuitka --standalone --onefile `
+        python -m nuitka --standalone `
                --enable-plugin=pyside6 `
                --assume-yes-for-downloads `
                --windows-console-mode=disable `
@@ -49,45 +50,62 @@ jobs:
                --windows-file-version=${{ steps.version.outputs.four_digit }} `
                --windows-product-version=${{ steps.version.outputs.clean_version }} `
                --include-data-dir=assets=assets `
-               --output-dir=dist `
+               --output-dir=dist-standalone `
                --output-filename=BiliDanmakuSender `
                run.py
 
-    - name: Prepare Assets (Rename & Zip)
+    - name: Build Onefile (Single EXE)
+      run: |
+        python -m nuitka --onefile `
+               --enable-plugin=pyside6 `
+               --assume-yes-for-downloads `
+               --windows-console-mode=disable `
+               --windows-icon-from-ico=assets/icon.ico `
+               --windows-file-version=${{ steps.version.outputs.four_digit }} `
+               --windows-product-version=${{ steps.version.outputs.clean_version }} `
+               --include-data-dir=assets=assets `
+               --output-dir=dist-onefile `
+               --output-filename=BiliDanmakuSender `
+               run.py
+
+    - name: Repackage and Rename Assets
+      shell: pwsh
       run: |
         $tag = "${{ steps.version.outputs.tag_name }}"
-        # 单文件版 (Onefile)
-        if (Test-Path "dist/BiliDanmakuSender.exe") {
-            Move-Item -Path "dist/BiliDanmakuSender.exe" -Destination "dist/BiliDanmakuSender-$tag-onefile-x64.exe"
+
+        if (Test-Path "dist-onefile/BiliDanmakuSender.exe") {
+            Move-Item -Path "dist-onefile/BiliDanmakuSender.exe" -Destination "BiliDanmakuSender-$tag-onefile-x64.exe"
         }
 
-        # 文件夹版 (Standalone)
-        $distFolder = Get-ChildItem -Path dist/*.dist -Directory | Select-Object -First 1
-        if ($distFolder) {
-            Rename-Item -Path $distFolder.FullName -NewName "AppDist"
+        if (Test-Path "dist-standalone/run.dist") {
+            Move-Item -Path "dist-standalone/run.dist" -Destination "AppDist"
+        }
 
-            if (-not (Test-Path "dist/AppDist/BiliDanmakuSender.exe")) {
-                 Write-Host "Warning: EXE not found in dist, checking logic..."
+        $targetExe = Get-ChildItem -Path "AppDist/*.exe" | Select-Object -First 1
+        if ($targetExe) {
+            if ($targetExe.Name -ne "BiliDanmakuSender.exe") {
+                Rename-Item -Path $targetExe.FullName -NewName "BiliDanmakuSender.exe"
             }
-            7z a -tzip -mx=9 "dist/BiliDanmakuSender-$tag-portable-x64.zip" "./dist/AppDist/*"
         }
 
-    - name: Download Chinese Language File
+        7z a -tzip -mx=9 "BiliDanmakuSender-$tag-portable-x64.zip" "./AppDist/*"
+
+    - name: Build Inno Setup Installer
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl" -OutFile "ChineseSimplified.isl"
 
-    - name: Build Inno Setup Installer
-      run: |
-        $tag = "${{ steps.version.outputs.tag_name }}"
-        iscc /DAppVersion="$tag" inno_setup.iss
+        if (!(Test-Path "Output")) { New-Item -ItemType Directory -Path "Output" }
 
-    - name: Upload Release Assets
+        $version = "${{ steps.version.outputs.clean_version }}"
+        iscc /DAppVersion="$version" inno_setup.iss
+
+    - name: Publish to GitHub Releases
       uses: softprops/action-gh-release@v2
       with:
         files: |
-          dist/BiliDanmakuSender-*-onefile-x64.exe
-          dist/BiliDanmakuSender-*-portable-x64.zip
-          dist/BiliDanmakuSender-*-setup-x64.exe
+          Output/BiliDanmakuSender-*-setup-x64.exe
+          BiliDanmakuSender-*-portable-x64.zip
+          BiliDanmakuSender-*-onefile-x64.exe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -1,4 +1,7 @@
-; 接收来自 GitHub Actions 传递的动态版本号
+; ---------------------------------------
+; BiliDanmakuSender - Inno Setup 配置文件
+; ---------------------------------------
+
 #ifndef AppVersion
 #define AppVersion "Unknown"
 #endif
@@ -6,35 +9,33 @@
 #define AppName "BiliDanmakuSender"
 #define AppExeName "BiliDanmakuSender.exe"
 #define AppPublisher "Miku_oso"
-#define AppPublisherURL "https://github.com/Mikuoso"
 #define AppSupportURL "https://touhougleaners.github.io/danmaku-sender/"
 #define AppUpdatesURL "https://github.com/TouhouGleaners/danmaku-sender/releases"
 
 [Setup]
 AppId={{CD28BCC5-45C6-4824-8579-75A641BFABE3}
+
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher={#AppPublisher}
-AppPublisherURL={#AppPublisherURL}
 AppSupportURL={#AppSupportURL}
 AppUpdatesURL={#AppUpdatesURL}
 
-; AppData\Local\Programs\Miku_oso\BiliDanmakuSender
-DefaultDirName={autopf}\Miku_oso\{#AppName}
+; 默认安装到当前用户的 Local Programs 目录
+DefaultDirName={autopf}\{#AppPublisher}\{#AppName}
 DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
 
-; 输出设置: 打包后的文件放在 dist 文件夹下
-OutputDir=dist
-OutputBaseFilename={#AppName}-{#AppVersion}-setup-x64
+; 构建产物输出
+OutputDir=Output
+OutputBaseFilename={#AppName}-v{#AppVersion}-setup-x64
 SetupIconFile=assets\icon.ico
 
-; 使用最高压缩率
+; 最高压缩率
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
 
-; 安装语言设置
 [Languages]
 Name: "chinesesimplified"; MessagesFile: "ChineseSimplified.isl"
 
@@ -42,14 +43,11 @@ Name: "chinesesimplified"; MessagesFile: "ChineseSimplified.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-; 指向 GitHub Actions 重命名后的 AppDist 目录
-Source: "dist\AppDist\BiliDanmakuSender.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "dist\AppDist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "AppDist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExeName}"
 Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExeName}"; Tasks: desktopicon
 
 [Run]
-; 安装完成后允许用户勾选“立即运行”
 Filename: "{app}\{#AppExeName}"; Description: "运行 {#AppName}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
通过添加动态版本处理和 Inno Setup 配置来增强构建过程。修复文件路径，确保正确引用打包的应用程序目录和 EXE 文件。引入下载中文语言文件的功能。更新构建过程以正确解析版本字符串并设置输出目录。

## Summary by Sourcery

更新发布构建工作流，以生成多个 Windows 构件，支持动态版本控制并包含安装程序。

新功能：
- 为发布构建添加支持，生成独立的 ZIP 包、单文件 EXE，以及 Inno Setup 安装程序。
- 引入从 Git 标签动态解析版本号，用于填充 Windows 二进制元数据和输出构件名称。
- 添加本地化的 Windows 安装程序，使用包含简体中文语言支持的 Inno Setup 配置。

增强：
- 优化构建产物的打包与命名，一致性地处理应用程序目录、可执行文件名称和发布资产匹配模式。

CI：
- 扩展 GitHub Actions 的发布工作流，以运行独立的 Nuitka 构建、重新打包输出，并通过 softprops/action-gh-release 发布所有生成的构件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the release build workflow to produce multiple Windows artifacts with dynamic versioning and an installer.

New Features:
- Add support for generating a standalone ZIP, a single-file EXE, and an Inno Setup installer from release builds.
- Introduce dynamic version parsing from Git tags to populate Windows binary metadata and output artifact names.
- Add a localized Windows installer using an Inno Setup configuration with Simplified Chinese language support.

Enhancements:
- Refine build artifact packaging and naming to consistently handle application directories, executable names, and release asset patterns.

CI:
- Extend the GitHub Actions release workflow to run separate Nuitka builds, repackage outputs, and publish all generated artifacts via softprops/action-gh-release.

</details>