### PR TITLE
feat(executor): 添加重试机制和中断支持，优化弹幕发送逻辑

### DIFF
--- a/src/danmaku_sender/core/engines/sender/executor.py
+++ b/src/danmaku_sender/core/engines/sender/executor.py
@@ -1,4 +1,5 @@
 import logging
+from threading import Event
 
 from ....api.bili_api_client import BiliApiClient
 from ...models.danmaku import Danmaku
@@ -19,34 +20,89 @@ class DanmakuExecutor:
         self.api_client = api_client
         self.logger = logging.getLogger("App.Sender.Executor")
 
-    def execute(self, target: VideoTarget, danmaku: Danmaku) -> DanmakuSendResult:
+    def execute(self, target: VideoTarget, danmaku: Danmaku, stop_event: Event) -> DanmakuSendResult:
         """
-        执行单次发送，并内聚处理所有底层的 HTTP / 业务异常
+        执行单次发送，并内聚处理所有底层的 HTTP / 业务异常, 提供重试
 
         Args:
             target(VideoTarget): 包含 cid 和 bvid 的视频目标
             danmaku(Danmaku): 待发送的实体数据
+            stop_event(Event): 发送过程中可监听的中断事件
 
         Returns:
             DanmakuSendResult: 标准化的结果实体。
         """
-        try:
-            params = danmaku.to_api_params()
-            resp_json = self.api_client.post_danmaku(target.cid, target.bvid, params)
-            result = DanmakuSendResult.from_api_response(resp_json)
+        attempt = 0
+        max_retries = 3
 
-            if result.is_success:
-                # 若 B 站 API 返回了 DMID，则回填给内存对象
-                if result.dmid:
-                    danmaku.dmid = result.dmid
-                self.logger.info(f"✅ 发送成功 [ID:{result.dmid}]: {danmaku.msg}")
-            else:
-                self.logger.warning(f"❌ 发送失败: {result.hint}")
+        while True:
+            try:
+                return self._send(target, danmaku)
 
-            return result
+            except BiliApiError as e:
+                # 业务异常: 若返回结果则终止；若返回 None 则代表休眠完毕，继续重试
+                if result := self._handle_api_error(e, attempt, max_retries, stop_event):
+                    return result
 
-        except BiliNetworkError as e:
-            self.logger.error(f"❌ 网络传输异常! 内容: '{danmaku.msg}', 错误: {e.message}")
+            except BiliNetworkError as e:
+                # 网络异常: 若返回结果则终止；若返回 None 则代表休眠完毕，继续重试
+                if result := self._handle_network_error(e, attempt, max_retries, stop_event):
+                    return result
+
+            attempt += 1
+
+    def _send(self, target: VideoTarget, danmaku: Danmaku) -> DanmakuSendResult:
+        """内部发包: 不捕获异常"""
+        params = danmaku.to_api_params()
+        resp_json = self.api_client.post_danmaku(target.cid, target.bvid, params)
+        result = DanmakuSendResult.from_api_response(resp_json)
+
+        if result.is_success:
+            # 若 B 站 API 返回了 DMID，则回填给内存对象
+            if result.dmid:
+                danmaku.dmid = result.dmid
+            self.logger.info(f"✅ 发送成功 [ID:{result.dmid}]: {danmaku.msg}")
+        else:
+            self.logger.warning(f"❌ 发送失败: {result.hint}")
+
+        return result
+
+    def _handle_api_error(self, e: BiliApiError, attempt: int, max_retries: int, stop_event: Event) -> DanmakuSendResult | None:
+        """
+        处理业务异常
+
+        非限流错误直接阻断 | 限流错误给予固定罚时重试
+        """
+        if e.code != BiliDmErrorCode.FREQ_LIMIT.code:
+            self.logger.error(f"❌ 请求被拒: {e.message}")
+            return DanmakuSendResult(
+                code=e.code,
+                is_success=False,
+                msg=e.message,
+                hint=BiliDmErrorCode.from_code(e.code).description
+            )
+
+        if attempt >= max_retries:
+            self.logger.error(f"❌ 频繁触发风控，重试 {max_retries} 次后放弃: {e.message}")
+            return DanmakuSendResult(
+                code=e.code,
+                is_success=False,
+                msg=e.message,
+                hint=BiliDmErrorCode.from_code(e.code).description
+            )
+
+        delay = 10.0
+        self.logger.warning(f"⚠️ 触发风控限流！进入 {delay} 秒惩罚等待 ({attempt + 1}/{max_retries})...")
+        return self._sleep_with_interrupt(delay, stop_event)
+
+    def _handle_network_error(self, e: BiliNetworkError, attempt: int, max_retries: int, stop_event: Event) -> DanmakuSendResult | None:
+        """
+        处理物理网络异常
+
+        基于指数退避计算重试延迟
+        """
+        if attempt >= max_retries:
+            self.logger.error(f"❌ 网络异常! 重试 {max_retries} 次后彻底失败: {e.message}")
             return DanmakuSendResult(
                 code=BiliDmErrorCode.NETWORK_ERROR.code,
                 is_success=False,
@@ -54,11 +110,22 @@ class DanmakuExecutor:
                 hint=BiliDmErrorCode.NETWORK_ERROR.description
             )
 
-        except BiliApiError as e:
-            self.logger.error(f"❌ 请求构造被拒: {e.message}")
+        delay = 2.0 * (2 ** attempt)  # 指数退避: 2s, 4s, 8s
+        self.logger.warning(f"⚠️ 网络波动 ({e.message})。将在 {delay} 秒后重试 ({attempt + 1}/{max_retries})...")
+        return self._sleep_with_interrupt(delay, stop_event)
+
+    def _sleep_with_interrupt(self, delay: float, stop_event: Event) -> DanmakuSendResult | None:
+        """
+        支持中断的休眠器
+
+        如果被人工打断，返回终止结果；否则返回 None 以继续流转
+        """
+        if stop_event.wait(delay):
+            self.logger.info("重试等待期间接收到停止指令，放弃发送。")
             return DanmakuSendResult(
-                code=e.code,
+                code=BiliDmErrorCode.CLIENT_RUNTIME_ERROR.code,
                 is_success=False,
-                msg=e.message,
-                hint=BiliDmErrorCode.from_code(e.code).description
+                msg="用户中断",
+                hint="发送任务已被手动停止"
             )
+        return None

--- a/src/danmaku_sender/core/engines/sender/scheduler.py
+++ b/src/danmaku_sender/core/engines/sender/scheduler.py
@@ -112,7 +112,7 @@ class DanmakuScheduler:
             self.logger.info(f"[{i+1}/{ctx.total}] 准备执行: {dm.msg}")
 
             # --- 委派 Executor 发送 ---
-            result = self.executor.execute(job.target, dm)
+            result = self.executor.execute(job.target, dm, job.stop_event)
 
             # --- 回调注入层 ---
             if job.result_callback:
@@ -122,18 +122,11 @@ class DanmakuScheduler:
             if not result.is_success:
                 ctx.add_unsent(dm, result.hint)
 
-                # A: 遭遇致命封禁，直接摧毁流水线
+                # 遭遇致命封禁，直接摧毁流水线
                 if result.is_fatal:
                     ctx.fatal_error_occurred = True
                     ctx.add_unsent(job.danmakus[i+1:], f"致命错误: {result.hint}")
                     break
-
-                # B: 遭遇风控限流，下发惩罚性延时
-                if result.code == BiliDmErrorCode.FREQ_LIMIT.code:
-                    self.logger.warning("⚠️ 触发频率限制！强制附加 10 秒惩罚延时...")
-                    if job.stop_event.wait(10.0):
-                        ctx.add_unsent(job.danmakus[i+1:], "任务在惩罚延时中被手动停止")
-                        break
             else:
                 ctx.success_count += 1
 


### PR DESCRIPTION
## Summary by Sourcery

为弹幕发送执行器添加重试和可中断等待机制，并精简围绕限流和失败处理的调度逻辑。

增强内容：
- 引入可配置的弹幕发送重试逻辑：在业务错误和网络错误场景下进行重试，并在限流时结合指数退避和固定惩罚性延迟。
- 增加可中断的休眠和停止事件支持，以便在重试等待期间可以取消发送操作。
- 重构调度器，将所有限流处理委托给执行器，并简化发送流水线中的失败处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retry and interruptible waiting to the danmaku sending executor and streamline scheduling logic around rate limiting and failures.

Enhancements:
- Introduce configurable retry logic for danmaku sending on both business and network errors with exponential backoff and fixed penalty delay for rate limiting.
- Add interruptible sleep and stop-event support so send operations can be cancelled during retry waits.
- Refactor scheduler to delegate all rate limit handling to the executor and simplify failure handling in the sending pipeline.

</details>