### PR TITLE
feat: 支持在工作区中右键插入新弹幕

### DIFF
--- a/src/danmaku_sender/core/engines/editor_session.py
+++ b/src/danmaku_sender/core/engines/editor_session.py
@@ -1,14 +1,18 @@
 import copy
-from hmac import new
 import uuid
 import logging
-from enum import Enum
+from enum import Enum, auto
 from dataclasses import dataclass, field
 from typing import Any, Callable, TypedDict
 
 from ..state import AppState
 from ..models.danmaku import Danmaku
 from ..services.danmaku_validator import validate_danmaku_list
+
+
+class InsertPosition(Enum):
+    ABOVE = auto()
+    BELOW = auto()
 
 
 @dataclass
@@ -235,13 +239,13 @@ class EditorSession:
         self.set_dirty(bool(self.undo_stack))
         return True
 
-    def insert_item(self, reference_uid: str, is_below: bool = True) -> str | None:
+    def insert_item(self, reference_uid: str, position: InsertPosition = InsertPosition.BELOW) -> str | None:
         """在指定弹幕附近插入一条新弹幕"""
         ref_item = self.items.get(reference_uid)
         if not ref_item:
             return None
 
-        offset = 500 if is_below else -500
+        offset = 500 if position == InsertPosition.BELOW else -500
         new_progress = max(0, ref_item.working.progress + offset)
 
         new_dm = Danmaku(

--- a/src/danmaku_sender/ui/editor_page.py
+++ b/src/danmaku_sender/ui/editor_page.py
@@ -1,5 +1,6 @@
 from hmac import new
 import logging
+from turtle import position
 from typing import Any, Callable
 
 from PySide6.QtCore import Qt, QAbstractTableModel, QModelIndex
@@ -14,7 +15,7 @@ from PySide6.QtWidgets import (
 from .dialogs import EditDanmakuDialog, TimeOffsetDialog
 from .framework.binder import UIBinder
 
-from ..core.engines.editor_session import EditorSession, EditorField
+from ..core.engines.editor_session import EditorSession, EditorField, InsertPosition
 from ..core.models.danmaku import Danmaku
 from ..core.state import AppState
 from ..utils.resource_utils import get_svg_icon
@@ -668,9 +669,9 @@ class EditorPage(QWidget):
         if action == edit_action:
             self._edit_row(index.row())
         elif action == insert_above_action:
-            self._insert_row(index.row(), is_below=False)
+            self._insert_row(index.row(), InsertPosition.ABOVE)
         elif action == insert_below_action:
-            self._insert_row(index.row(), is_below=True)
+            self._insert_row(index.row(), InsertPosition.BELOW)
         elif action == delete_action:
             self.delete_selected_items()
 
@@ -696,7 +697,7 @@ class EditorPage(QWidget):
                     self.session.delete_items([item_id])
                     self._refresh_table()
 
-    def _insert_row(self, row: int, is_below: bool):
+    def _insert_row(self, row: int, position: InsertPosition):
         """插入新弹幕"""
         if not self.session:
             return
@@ -705,7 +706,7 @@ class EditorPage(QWidget):
         if not item_id:
             return
 
-        new_uid = self.session.insert_item(item_id, is_below=is_below)
+        new_uid = self.session.insert_item(item_id, position)
         if new_uid:
             self._refresh_table()
             # 定位到新插入的行


### PR DESCRIPTION
引入通过右键上下文菜单在现有弹幕上方或下方插入新弹幕项的功能。重构代码，使用枚举表示插入位置以提高可读性。

## Summary by Sourcery

在编辑器表格的上下文菜单中添加在现有弹幕条目上方或下方插入新弹幕的支持，并将其接入编辑会话。

新功能：
- 允许通过表格上下文菜单在选中行的上方或下方插入新的弹幕。
- 在编辑会话中在参考条目附近创建新的弹幕项，继承其样式并调整进度。

改进：
- 引入 `InsertPosition` 枚举，以在编辑会话中明确插入位置的语义。
- 在表格刷新后自动聚焦并打开新插入的弹幕行的编辑器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for inserting new danmaku entries above or below an existing one from the editor table context menu and wire it into the editor session.

New Features:
- Allow inserting a new danmaku above or below the selected row via the table context menu.
- Create new danmaku items near a reference item in the editor session with inherited style and adjusted progress.

Enhancements:
- Introduce an InsertPosition enum to clarify insertion location semantics in the editor session.
- Automatically focus and open the editor for newly inserted danmaku rows after table refresh.

</details>