### PR TITLE
refactor(core,ui): 重命名所有自定义信号为小驼峰(camelCase)以严格对齐 Qt 官方规范

### DIFF
--- a/src/danmaku_sender/ui/controllers/system_controller.py
+++ b/src/danmaku_sender/ui/controllers/system_controller.py
@@ -17,9 +17,9 @@ def _check_update(use_proxy: bool):
 
 class SystemController(QObject):
     """系统业务控制器 (更新检查等)"""
-    update_found = Signal(str, str, str)  # version, notes, url
-    no_update = Signal(bool)              # 是否需要展示“已是最新”弹窗
-    check_failed = Signal(str, bool)      # 错误信息, 是否需要展示“检查失败”弹窗
+    updateFound = Signal(str, str, str)  # version, notes, url
+    updateNotFound = Signal(bool)              # 是否需要展示“已是最新”弹窗
+    checkFailed = Signal(str, bool)      # 错误信息, 是否需要展示“检查失败”弹窗
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -54,9 +54,9 @@ class SystemController(QObject):
         self._in_flight_is_manual = False
 
         if info.has_update:
-            self.update_found.emit(info.remote_version, info.release_notes, info.url)
+            self.updateFound.emit(info.remote_version, info.release_notes, info.url)
         else:
-            self.no_update.emit(is_manual)
+            self.updateNotFound.emit(is_manual)
 
     def _on_check_failed(self, err: str):
         """内部回调：更新检查失败"""
@@ -67,4 +67,4 @@ class SystemController(QObject):
         self._in_flight_is_manual = False
 
         # 如果是手动点的，通知 UI 报错
-        self.check_failed.emit(err, is_manual)
+        self.checkFailed.emit(err, is_manual)

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -169,7 +169,7 @@ class ValidationRulesGroup(QGroupBox):
 
 class DanmakuPropertyForm(QWidget):
     """模块内高度内聚的表单控件，用于 Inspector 和 Dialog 共享"""
-    text_changed = Signal(str)
+    textChanged = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -216,7 +216,7 @@ class DanmakuPropertyForm(QWidget):
         layout.addWidget(QLabel("弹幕内容:"))
         self.prop_text = QTextEdit()
         self.prop_text.setAcceptRichText(False)
-        self.prop_text.textChanged.connect(lambda: self.text_changed.emit(self.get_cleaned_text()))
+        self.prop_text.textChanged.connect(lambda: self.textChanged.emit(self.get_cleaned_text()))
         layout.addWidget(self.prop_text)
 
     def _init_bili_palette(self):
@@ -273,7 +273,7 @@ class DanmakuPropertyForm(QWidget):
         self.prop_text.blockSignals(True)
         self.prop_text.setPlainText(dm.msg)
         self.prop_text.blockSignals(False)
-        self.text_changed.emit(self.get_cleaned_text())
+        self.textChanged.emit(self.get_cleaned_text())
 
     def clear_form(self):
         self.prop_time.setValue(0.0)

--- a/src/danmaku_sender/ui/editor/dialogs.py
+++ b/src/danmaku_sender/ui/editor/dialogs.py
@@ -42,7 +42,7 @@ class EditDanmakuDialog(QDialog):
         footer_layout.addWidget(self.btn_ok)
         layout.addLayout(footer_layout)
 
-        self.editor_widget.text_changed.connect(self._update_counter)
+        self.editor_widget.textChanged.connect(self._update_counter)
 
     @Slot(str)
     def _update_counter(self, text: str):

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -314,11 +314,11 @@ class MainWindow(QMainWindow):
         self.state.senderActiveChanged.connect(self._refresh_sidebar_badges)
 
         # 自动更新检查流
-        self.system_controller.update_found.connect(self._on_update_found)
-        self.system_controller.no_update.connect(lambda is_m:
+        self.system_controller.updateFound.connect(self._on_update_found)
+        self.system_controller.updateNotFound.connect(lambda is_m:
             QMessageBox.information(self, "检查更新", "当前已是最新版本。") if is_m else None
         )
-        self.system_controller.check_failed.connect(lambda err, is_m:
+        self.system_controller.checkFailed.connect(lambda err, is_m:
             QMessageBox.warning(self, "检查更新失败", f"无法连接到更新服务器:\n{err}") if is_m else None
         )
 


### PR DESCRIPTION
## Summary by Sourcery

在核心 UI 组件中将自定义 Qt 信号统一重命名为 camelCase，以符合 Qt 命名规范。

增强内容：
- 将 `SystemController` 的更新和错误信号及其使用位置重命名为 camelCase 格式的名称。
- 将 `DanmakuPropertyForm` 的文本变更信号及其连接重命名为 camelCase 格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename custom Qt signals to camelCase across core UI components to align with Qt naming conventions.

Enhancements:
- Rename SystemController update and error signals and their usages to camelCase names.
- Rename DanmakuPropertyForm text change signal and its connections to camelCase.

</details>