### PR TITLE
fix(ui/editor): 新增或导入弹幕时自动开启全量预览并聚焦，消除操作无效的错觉

### DIFF
--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -262,6 +262,7 @@ class EditorPage(QWidget):
                 return
 
         self.controller.create_new_workspace()
+        self.preview_mode_cb.setChecked(True)
         self.current_item_id = None
         self.inspector_group.reset_inspector()
         QMessageBox.information(self, "新建成功", "已创建空白工作区，你可以开始创作了！")
@@ -288,6 +289,7 @@ class EditorPage(QWidget):
             try:
                 count = self.controller.import_xml_workspace(file_path)
                 if count > 0:
+                    self.preview_mode_cb.setChecked(True)
                     self.current_item_id = None
                     self.inspector_group.reset_inspector()
                     QMessageBox.information(
@@ -476,6 +478,8 @@ class EditorPage(QWidget):
 
         new_uid = self.controller.insert_item(uid, position)
         if new_uid:
+            self.preview_mode_cb.setChecked(True)
+
             for i in range(self.model.rowCount()):
                 if self.model.get_item_id(i) == new_uid:
                     self.table.selectRow(i)
@@ -504,6 +508,8 @@ class EditorPage(QWidget):
             )
 
             if new_uids:
+                self.preview_mode_cb.setChecked(True)
+
                 for i in range(self.model.rowCount()):
                     if self.model.get_item_id(i) == new_uids[0]:
                         self.table.selectRow(i)


### PR DESCRIPTION
## Summary by Sourcery

在编辑器中创建、导入、插入或批量生成弹幕项目时，自动启用预览模式，以便新内容可以立即可见并获得焦点。

新功能：
- 在编辑器中创建新的工作区或导入 XML 工作区后，自动启用完整预览模式。
- 在编辑器中插入新的弹幕行或生成弹幕项目数组后，自动启用完整预览模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure preview mode is automatically enabled when creating, importing, inserting, or batch-generating danmaku items in the editor to make new content immediately visible and focused.

New Features:
- Automatically enable full preview mode after creating a new workspace or importing an XML workspace in the editor.
- Automatically enable full preview mode after inserting a new danmaku row or generating an array of danmaku items in the editor.

</details>