### PR TITLE
refactor(ui): 重构历史记录页面结构，抽离为独立目录模块

### DIFF
--- a/src/danmaku_sender/ui/history/__init__.py
+++ b/src/danmaku_sender/ui/history/__init__.py
@@ -1,0 +1,4 @@
+from .page import HistoryPage
+
+
+__all__ = ["HistoryPage"]

--- a/src/danmaku_sender/ui/history/components.py
+++ b/src/danmaku_sender/ui/history/components.py
@@ -1,0 +1,139 @@
+from enum import IntEnum
+from datetime import datetime
+
+from PySide6.QtCore import Qt, QAbstractTableModel, QModelIndex
+from PySide6.QtGui import QColor, QBrush
+
+from ...core.database.history_manager import DanmakuStatus
+from ...core.entities.video import VideoInfo
+
+
+class Col(IntEnum):
+    BVID = 0
+    PART = 1
+    MSG = 2
+    STATUS = 3
+    TIME = 4
+
+
+class HistoryTableModel(QAbstractTableModel):
+    HEADERS = ["BVID", "分P", "弹幕内容", "状态", "发送时间"]
+
+    def __init__(self, parent = None):
+        super().__init__(parent)
+        self._records = []
+        self._video_cache: dict[str, VideoInfo] = {}  # Key: BVID, Value: VideoInfo
+        self._loading_bvids = set()
+
+    def set_records(self, records):
+        self.beginResetModel()
+        self._records = records
+        self.endResetModel()
+
+    def mark_as_loading(self, bvid):
+        self._loading_bvids.add(bvid)
+        self.layoutChanged.emit()
+
+    def update_video_cache(self, bvid: str, info: VideoInfo | None):
+        if info:
+            self._video_cache[bvid] = info
+
+        if bvid in self._loading_bvids:
+            self._loading_bvids.remove(bvid)
+
+        self.layoutChanged.emit()
+
+    def get_video_info(self, bvid: str) -> VideoInfo | None:
+        return self._video_cache.get(bvid)
+
+    def get_record_at(self, row):
+        if 0 <= row < len(self._records):
+            return self._records[row]
+        return None
+
+    # --- Qt Methods ---
+    def rowCount(self, parent = QModelIndex()):
+        return len(self._records)
+
+    def columnCount(self, parent = QModelIndex()):
+        return len(self.HEADERS)
+
+    def headerData(self, section, orientation, role):
+        if orientation == Qt.Orientation.Horizontal and role == Qt.ItemDataRole.DisplayRole:
+            return self.HEADERS[section]
+        return None
+
+    def data(self, index: QModelIndex, role = Qt.ItemDataRole.DisplayRole):
+        if not index.isValid():
+            return None
+
+        record = self._records[index.row()]
+        col = index.column()
+
+        if role == Qt.ItemDataRole.DisplayRole:
+            return self._get_display_text(record, col)
+        elif role == Qt.ItemDataRole.ForegroundRole:
+            return self._get_text_color(record, col)
+        elif role == Qt.ItemDataRole.ToolTipRole:
+            return self._get_tooltip(record, col)
+
+        return None
+
+    def _get_display_text(self, record, col):
+        if col == Col.BVID:
+            return record['bvid']
+
+        if col == Col.PART:
+            bvid = record['bvid']
+            video_info = self._video_cache.get(bvid)
+
+            if video_info:
+                part = video_info.get_part_by_cid(record['cid'])
+                if part:
+                    return f"P{part.page}"
+
+            if bvid in self._loading_bvids:
+                return "..."
+
+            return f"CID: {record['cid']}"
+
+        if col == Col.MSG:
+            return record['msg']
+
+        if col == Col.STATUS:
+            status = record['status']
+            if status == DanmakuStatus.VERIFIED:
+                return "已存活"
+            if status == DanmakuStatus.LOST:
+                return "已丢失"
+            return "待验证"
+
+        if col == Col.TIME:
+            return datetime.fromtimestamp(record['ctime']).strftime('%Y-%m-%d %H:%M:%S')
+
+        return ""
+
+    def _get_text_color(self, record, col):
+        if col == Col.STATUS:
+            status = record['status']
+            if status == DanmakuStatus.VERIFIED:
+                return QBrush(QColor("#27ae60"))
+            if status == DanmakuStatus.LOST:
+                return QBrush(QColor("#c0392b"))
+            return QBrush(QColor("#f39c12"))
+        return None
+
+    def _get_tooltip(self, record, col):
+        video_info = self._video_cache.get(record['bvid'])
+
+        if col == Col.BVID:
+            return video_info.title if video_info else "正在获取..."
+
+        if col == Col.PART:
+            if video_info:
+                part = video_info.get_part_by_cid(record['cid'])
+                if part:
+                    return f"P{part.page} - {part.title}"
+            return f"CID: {record['cid']}"
+
+        return None

--- a/src/danmaku_sender/ui/history/dialogs.py
+++ b/src/danmaku_sender/ui/history/dialogs.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QFormLayout, QLabel, QFrame
+
+from ...core.entities.video import VideoInfo
+from ...core.database.history_manager import DanmakuStatus
+
+
+class DanmakuDetailDialog(QDialog):
+    def __init__(self, record: dict, video_info: VideoInfo | None, parent= None):
+        super().__init__(parent)
+        self.setWindowTitle("弹幕详情档案")
+        self.resize(500, 450)
+        self._record = record
+        self._video_info = video_info
+        self._create_ui()
+
+    def _create_ui(self):
+        layout = QFormLayout(self)
+        layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
+
+        def add_row(label, value):
+            lbl = QLabel(str(value))
+            lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+            lbl.setWordWrap(True)
+            layout.addRow(f"{label}:", lbl)
+
+        # --- 视频元数据 ---
+        layout.addRow(QLabel("<b>[ 视频信息 ]</b>"))
+
+        cid = self._record['cid']
+        bvid = self._record['bvid']
+
+        # 尝试从 VideoInfo 对象获取分P信息
+        part_idx = "未知"
+        part_title = "-"
+        video_title = "加载中或未知..."
+
+        if self._video_info:
+            video_title = self._video_info.title
+            part = self._video_info.get_part_by_cid(cid)
+            if part:
+                part_idx = f"P{part.page}"
+                part_title = part.title
+
+        add_row("BVID", bvid)
+        add_row("视频标题", video_title)
+        add_row("分P序号", part_idx)
+        add_row("分P标题", part_title)
+        add_row("CID", cid)
+
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        layout.addRow(line)
+
+        # --- 弹幕参数 ---
+        layout.addRow(QLabel("<b>[ 弹幕参数 ]</b>"))
+
+        status_map = {
+            DanmakuStatus.PENDING: "⏳ 待验证",
+            DanmakuStatus.VERIFIED: "✅ 已存活",
+            DanmakuStatus.LOST: "❌ 已丢失"
+        }
+        status = status_map.get(self._record['status'], "未知")
+        if self._record.get('is_visible', 1) == 0:
+            status += " (API返回屏蔽)"
+
+        add_row("当前状态", status)
+        add_row("弹幕内容", self._record['msg'])
+        add_row("DmID", self._record['dmid'])
+        add_row("发送时间", datetime.fromtimestamp(self._record['ctime']).strftime('%Y-%m-%d %H:%M:%S'))
+        add_row("视频内时间", f"{self._record['progress']} ms")
+        add_row("字号", self._record['fontsize'])
+        add_row("颜色", f"#{self._record['color']:06x}")

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -1,223 +1,23 @@
 import logging
-from enum import IntEnum
-from datetime import datetime
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QComboBox,
-    QPushButton, QTableView, QHeaderView, QAbstractItemView, QMenu,
-    QApplication, QDialog, QFormLayout, QFrame
+    QPushButton, QTableView, QHeaderView, QAbstractItemView, QMenu, QApplication
 )
-from PySide6.QtCore import Qt, QAbstractTableModel, QModelIndex, QUrl, Slot, QPoint
-from PySide6.QtGui import QAction, QColor, QDesktopServices, QBrush
+from PySide6.QtCore import Qt, QModelIndex, QUrl, Slot, QPoint
+from PySide6.QtGui import QAction, QDesktopServices
 
-from .controllers.video_controller import VideoController
-from .controllers.history_controller import HistoryController
+from .components import Col, HistoryTableModel
+from .dialogs import DanmakuDetailDialog
+from ..controllers.video_controller import VideoController
+from ..controllers.history_controller import HistoryController
 
-from ..core.database.history_manager import DanmakuStatus
-from ..core.entities.video import VideoInfo
-from ..core.state import AppState
+from ...core.database.history_manager import DanmakuStatus
+from ...core.entities.video import VideoInfo
+from ...core.state import AppState
 
 
 logger = logging.getLogger("App.System.UI.History")
-
-
-class Col(IntEnum):
-    BVID = 0
-    PART = 1
-    MSG = 2
-    STATUS = 3
-    TIME = 4
-
-
-class DanmakuDetailDialog(QDialog):
-    def __init__(self, record: dict, video_info: VideoInfo | None, parent= None):
-        super().__init__(parent)
-        self.setWindowTitle("弹幕详情档案")
-        self.resize(500, 450)
-        self._record = record
-        self._video_info = video_info
-        self._create_ui()
-
-    def _create_ui(self):
-        layout = QFormLayout(self)
-        layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight)
-
-        def add_row(label, value):
-            lbl = QLabel(str(value))
-            lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
-            lbl.setWordWrap(True)
-            layout.addRow(f"{label}:", lbl)
-
-        # --- 视频元数据 ---
-        layout.addRow(QLabel("<b>[ 视频信息 ]</b>"))
-
-        cid = self._record['cid']
-        bvid = self._record['bvid']
-
-        # 尝试从 VideoInfo 对象获取分P信息
-        part_idx = "未知"
-        part_title = "-"
-        video_title = "加载中或未知..."
-
-        if self._video_info:
-            video_title = self._video_info.title
-            part = self._video_info.get_part_by_cid(cid)
-            if part:
-                part_idx = f"P{part.page}"
-                part_title = part.title
-
-        add_row("BVID", bvid)
-        add_row("视频标题", video_title)
-        add_row("分P序号", part_idx)
-        add_row("分P标题", part_title)
-        add_row("CID", cid)
-
-        line = QFrame()
-        line.setFrameShape(QFrame.Shape.HLine)
-        layout.addRow(line)
-
-        # --- 弹幕参数 ---
-        layout.addRow(QLabel("<b>[ 弹幕参数 ]</b>"))
-
-        status_map = {
-            DanmakuStatus.PENDING: "⏳ 待验证",
-            DanmakuStatus.VERIFIED: "✅ 已存活",
-            DanmakuStatus.LOST: "❌ 已丢失"
-        }
-        status = status_map.get(self._record['status'], "未知")
-        if self._record.get('is_visible', 1) == 0:
-            status += " (API返回屏蔽)"
-
-        add_row("当前状态", status)
-        add_row("弹幕内容", self._record['msg'])
-        add_row("DmID", self._record['dmid'])
-        add_row("发送时间", datetime.fromtimestamp(self._record['ctime']).strftime('%Y-%m-%d %H:%M:%S'))
-        add_row("视频内时间", f"{self._record['progress']} ms")
-        add_row("字号", self._record['fontsize'])
-        add_row("颜色", f"#{self._record['color']:06x}")
-
-
-class HistoryTableModel(QAbstractTableModel):
-    HEADERS = ["BVID", "分P", "弹幕内容", "状态", "发送时间"]
-
-    def __init__(self, parent = None):
-        super().__init__(parent)
-        self._records = []
-        self._video_cache: dict[str, VideoInfo] = {}  # Key: BVID, Value: VideoInfo
-        self._loading_bvids = set()
-
-    def set_records(self, records):
-        self.beginResetModel()
-        self._records = records
-        self.endResetModel()
-
-    def mark_as_loading(self, bvid):
-        self._loading_bvids.add(bvid)
-        self.layoutChanged.emit()
-
-    def update_video_cache(self, bvid: str, info: VideoInfo | None):
-        if info:
-            self._video_cache[bvid] = info
-
-        if bvid in self._loading_bvids:
-            self._loading_bvids.remove(bvid)
-
-        self.layoutChanged.emit()
-
-    def get_video_info(self, bvid: str) -> VideoInfo | None:
-        return self._video_cache.get(bvid)
-
-    def get_record_at(self, row):
-        if 0 <= row < len(self._records):
-            return self._records[row]
-        return None
-
-    # --- Qt Methods ---
-    def rowCount(self, parent = QModelIndex()):
-        return len(self._records)
-
-    def columnCount(self, parent = QModelIndex()):
-        return len(self.HEADERS)
-
-    def headerData(self, section, orientation, role):
-        if orientation == Qt.Orientation.Horizontal and role == Qt.ItemDataRole.DisplayRole:
-            return self.HEADERS[section]
-        return None
-
-    def data(self, index: QModelIndex, role = Qt.ItemDataRole.DisplayRole):
-        if not index.isValid():
-            return None
-
-        record = self._records[index.row()]
-        col = index.column()
-
-        if role == Qt.ItemDataRole.DisplayRole:
-            return self._get_display_text(record, col)
-        elif role == Qt.ItemDataRole.ForegroundRole:
-            return self._get_text_color(record, col)
-        elif role == Qt.ItemDataRole.ToolTipRole:
-            return self._get_tooltip(record, col)
-
-        return None
-
-    def _get_display_text(self, record, col):
-        if col == Col.BVID:
-            return record['bvid']
-
-        if col == Col.PART:
-            bvid = record['bvid']
-            video_info = self._video_cache.get(bvid)
-
-            if video_info:
-                part = video_info.get_part_by_cid(record['cid'])
-                if part:
-                    return f"P{part.page}"
-
-            if bvid in self._loading_bvids:
-                return "..."
-
-            return f"CID: {record['cid']}"
-
-        if col == Col.MSG:
-            return record['msg']
-
-        if col == Col.STATUS:
-            status = record['status']
-            if status == DanmakuStatus.VERIFIED:
-                return "已存活"
-            if status == DanmakuStatus.LOST:
-                return "已丢失"
-            return "待验证"
-
-        if col == Col.TIME:
-            return datetime.fromtimestamp(record['ctime']).strftime('%Y-%m-%d %H:%M:%S')
-
-        return ""
-
-    def _get_text_color(self, record, col):
-        if col == Col.STATUS:
-            status = record['status']
-            if status == DanmakuStatus.VERIFIED:
-                return QBrush(QColor("#27ae60"))
-            if status == DanmakuStatus.LOST:
-                return QBrush(QColor("#c0392b"))
-            return QBrush(QColor("#f39c12"))
-        return None
-
-    def _get_tooltip(self, record, col):
-        video_info = self._video_cache.get(record['bvid'])
-
-        if col == Col.BVID:
-            return video_info.title if video_info else "正在获取..."
-
-        if col == Col.PART:
-            if video_info:
-                part = video_info.get_part_by_cid(record['cid'])
-                if part:
-                    return f"P{part.page} - {part.title}"
-            return f"CID: {record['cid']}"
-
-        return None
 
 
 class HistoryPage(QWidget):

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -18,7 +18,7 @@ from .settings_page import SettingsPage
 from .monitor_page import MonitorPage
 from .editor import EditorPage
 from .dialogs import AboutDialog, HelpDialog, UpdateDialog
-from .history_page import HistoryPage
+from .history import HistoryPage
 from .theme_manager import ThemeManager
 
 from ..config.app_config import AppInfo, UI


### PR DESCRIPTION
## 由 Sourcery 生成的总结

将历史记录 UI 重构为独立的模块结构，并相应调整导入。

改进内容：
- 将历史记录表格组件和详情对话框提取为位于 `ui.history` 下的可复用独立模块。
- 将历史记录页面重组到 `ui.history` 包中，使文件结构更清晰，并使用相对导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the history UI into a dedicated module structure and adjust imports accordingly.

Enhancements:
- Extract history table components and detail dialog into separate reusable modules under ui.history.
- Reorganize the history page into the ui.history package with a cleaner file layout and relative imports.

</details>