### PR TITLE
refactor(sender): 将 ETA 计算逻辑下沉至 Worker，实现 UI 层与引擎层的彻底解耦

### DIFF
--- a/src/danmaku_sender/core/engines/sender/delay_manager.py
+++ b/src/danmaku_sender/core/engines/sender/delay_manager.py
@@ -2,12 +2,12 @@ import random
 import logging
 from threading import Event
 
+
 class DelayManager:
     """
     发送节奏管理器 (Pacing / Delay Manager)
 
-    设计意图：将“算时间”和“等时间”剥离成独立的控制模块。
-    支持基础的随机波动延时，以及模拟真实人类批量操作习惯的“爆发-休息”模式。
+    支持基础的随机波动延时，以及模拟人类批量操作习惯的“爆发-休息”模式。
     """
     def __init__(
         self,
@@ -76,3 +76,35 @@ class DelayManager:
             return True
 
         return False
+
+    @staticmethod
+    def calc_eta(attempted: int, total: int, burst_size: int, avg_normal: float, avg_rest: float) -> float:
+        """
+        计算剩余等待时间 (O(1))。
+
+        契约 (Contract):
+        1. 延时发生在发送动作之后，因此最后一条弹幕发完不产生延时，总延时次数为 total - 1。
+        2. 延时的物理索引从 1 开始（第 k 条弹幕发完后的延时索引为 k）。
+        3. 仅当延时索引能被 burst_size 整除时，触发大休息 (avg_rest)。
+        """
+        # 防御性校验：避免除零及负数异常
+        if burst_size <= 0:
+            burst_size = 1
+
+        # 统一处理 0 和 1 进度：
+        # 准备开始(0)和准备发第1条(1)时，前面都没有发生过延时，
+        # 其后续的延时索引区间都是 [1, total - 1]。
+        current_k = max(1, attempted)
+        remaining_waits = total - current_k
+
+        if remaining_waits <= 0:
+            return 0.0
+
+        if burst_size == 1:
+            return remaining_waits * avg_normal
+
+        # 在闭区间 [current_k, total - 1] 中，计算能被 burst_size 整除的元素个数
+        rest_count = (total - 1) // burst_size - (current_k - 1) // burst_size
+        normal_count = remaining_waits - rest_count
+
+        return (normal_count * avg_normal) + (rest_count * avg_rest)

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -3,16 +3,17 @@ import threading
 
 from PySide6.QtCore import QObject, Signal, Slot
 
-from ..framework.concurrency import BaseWorker
+from danmaku_sender.ui.framework.concurrency import BaseWorker
 
-from ...core.database.history_manager import HistoryManager
-from ...core.engines.sender import DanmakuScheduler, DanmakuExecutor, SendingContext, SendJob
-from ...core.entities.danmaku import Danmaku
-from ...core.types.result import DanmakuSendResult
-from ...core.types.common import VideoTarget
-from ...core.state import ApiAuthConfig, SenderConfig
-from ...api.bili_api_client import BiliApiClient
-from ...utils.system_utils import KeepSystemAwake
+from danmaku_sender.core.database.history_manager import HistoryManager
+from danmaku_sender.core.engines.sender import DanmakuScheduler, DanmakuExecutor, SendingContext, SendJob
+from danmaku_sender.core.engines.sender.delay_manager import DelayManager
+from danmaku_sender.core.entities.danmaku import Danmaku
+from danmaku_sender.core.types.result import DanmakuSendResult
+from danmaku_sender.core.types.common import VideoTarget
+from danmaku_sender.core.state import ApiAuthConfig, SenderConfig
+from danmaku_sender.api.bili_api_client import BiliApiClient
+from danmaku_sender.utils.system_utils import KeepSystemAwake
 
 
 logger = logging.getLogger("App.System.SenderController")
@@ -20,7 +21,7 @@ logger = logging.getLogger("App.System.SenderController")
 
 class SenderController(QObject):
     """发送任务业务控制器"""
-    progressUpdated = Signal(int, int)
+    progressUpdated = Signal(int, int, float)
     taskFinished = Signal(object)
 
     def __init__(self, parent=None):
@@ -90,8 +91,8 @@ class SenderController(QObject):
 
 class SendTaskWorker(BaseWorker):
     """用于后台发送弹幕的线程"""
-    progressUpdated = Signal(int, int)  # 已尝试, 总数
-    taskFinished = Signal(object)       # SendingContext
+    progressUpdated = Signal(int, int, float)  # 已尝试, 总数, ETA
+    taskFinished = Signal(object)              # SendingContext
 
     def __init__(
         self,
@@ -143,7 +144,18 @@ class SendTaskWorker(BaseWorker):
             return self.scheduler.run_pipeline(job)
 
     def _handle_job_progress(self, attempted: int, total: int):
-        self.progressUpdated.emit(attempted, total)
+        avg_normal = (self.strategy_config.min_delay + self.strategy_config.max_delay) / 2
+        avg_rest = (self.strategy_config.rest_min + self.strategy_config.rest_max) / 2
+
+        eta_sec = DelayManager.calc_eta(
+            attempted=attempted,
+            total=total,
+            burst_size=self.strategy_config.burst_size,
+            avg_normal=avg_normal,
+            avg_rest=avg_rest
+        )
+
+        self.progressUpdated.emit(attempted, total, eta_sec)
 
     def _handle_job_result(self, dm: Danmaku, result: DanmakuSendResult):
         if result.is_success and result.dmid:

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -450,8 +450,8 @@ class MainWindow(QMainWindow):
         if reason == QSystemTrayIcon.ActivationReason.Trigger:
             self._show_from_tray()
 
-    @Slot(int, int)
-    def _on_sender_progress_sync(self, att: int, total: int):
+    @Slot(int, int, float)
+    def _on_sender_progress_sync(self, att: int, total: int, eta_sec: float):
         self._current_sender_progress = (att, total)
         self._refresh_global_status()
 

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -10,21 +10,20 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent
 from PySide6.QtCore import Qt, QDateTime, Slot
 
-from danmaku_sender.core.engines.sender.context import SendingContext
-
 from .framework.binder import UIBinder
 from .framework.style_loader import get_svg_icon
 from .controllers.video_controller import VideoController
 from .controllers.sender_controller import SenderController
 
-from ..core.entities.video import VideoInfo
-from ..core.types.common import VideoTarget
-from ..core.services.danmaku_exporter import UnsentDanmakusRecord, create_xml_from_danmakus
-from ..core.services.danmaku_parser import DanmakuParser
-from ..core.state import AppState
-from ..utils.string_utils import parse_bilibili_link
-from ..utils.time_utils import format_duration
-from ..utils.notification_utils import send_windows_notification
+from danmaku_sender.core.engines.sender.context import SendingContext
+from danmaku_sender.core.entities.video import VideoInfo
+from danmaku_sender.core.types.common import VideoTarget
+from danmaku_sender.core.services.danmaku_exporter import UnsentDanmakusRecord, create_xml_from_danmakus
+from danmaku_sender.core.services.danmaku_parser import DanmakuParser
+from danmaku_sender.core.state import AppState
+from danmaku_sender.utils.string_utils import parse_bilibili_link
+from danmaku_sender.utils.time_utils import format_duration
+from danmaku_sender.utils.notification_utils import send_windows_notification
 
 
 class SenderPage(QWidget):
@@ -315,8 +314,8 @@ class SenderPage(QWidget):
     # endregion
     # region Slots SenderController
 
-    @Slot(int, int)
-    def _on_send_progress(self, attempted: int, total: int):
+    @Slot(int, int, float)
+    def _on_send_progress(self, attempted: int, total: int, eta_sec: float):
         if total > 0:
             val = int((attempted / total) * 100)
             self.progress_bar.setValue(val)
@@ -324,7 +323,6 @@ class SenderPage(QWidget):
             # ETA 计算逻辑
             remaining = total - attempted
             if remaining > 0:
-                eta_sec = self._calculate_eta_seconds(attempted, total)
                 duration = format_duration(eta_sec)
                 finish_time = QDateTime.currentDateTime().addSecs(int(eta_sec)).toString("HH:mm:ss")
                 display_text = f"%p% (剩余 {duration} | 预计 {finish_time} 结束)"
@@ -358,55 +356,6 @@ class SenderPage(QWidget):
 
     # endregion
     # endregion
-
-    def _calculate_eta_seconds(self, attempted: int, total: int) -> float:
-        """从状态中提取配置，并调用纯数学方法计算 ETA"""
-        if not self._state:
-            return 0.0
-
-        cfg = self._state.sender_config
-        avg_normal = (cfg.min_delay + cfg.max_delay) / 2
-        avg_rest = (cfg.rest_min + cfg.rest_max) / 2
-
-        return self._math_calc_eta(
-            attempted=attempted,
-            total=total,
-            burst_size=cfg.burst_size,
-            avg_normal=avg_normal,
-            avg_rest=avg_rest
-        )
-
-    @staticmethod
-    def _math_calc_eta(attempted: int, total: int, burst_size: int, avg_normal: float, avg_rest: float) -> float:
-        """
-        计算剩余等待时间的纯数学辅助函数 (O(1))。
-
-        契约 (Contract):
-        1. 延时发生在发送动作之后，因此最后一条弹幕发完不产生延时，总延时次数为 total - 1。
-        2. 延时的物理索引从 1 开始（第 k 条弹幕发完后的延时索引为 k）。
-        3. 仅当延时索引能被 burst_size 整除时，触发大休息 (avg_rest)。
-        """
-        # 防御性校验：避免除零及负数异常
-        if burst_size <= 0:
-            burst_size = 1
-
-        # 统一处理 0 和 1 进度：
-        # 准备开始(0)和准备发第1条(1)时，前面都没有发生过延时，
-        # 其后续的延时索引区间都是 [1, total - 1]。
-        current_k = max(1, attempted)
-        remaining_waits = total - current_k
-
-        if remaining_waits <= 0:
-            return 0.0
-
-        if burst_size == 1:
-            return remaining_waits * avg_normal
-
-        # 在闭区间 [current_k, total - 1] 中，计算能被 burst_size 整除的元素个数
-        rest_count = (total - 1) // burst_size - (current_k - 1) // burst_size
-        normal_count = remaining_waits - rest_count
-
-        return (normal_count * avg_normal) + (rest_count * avg_rest)
 
     def _send_desktop_notification(self, ctx: SendingContext, is_stopped: bool):
         """发送系统桌面通知"""


### PR DESCRIPTION
## Summary by Sourcery

通过将弹幕发送的 ETA（预计完成时间）计算从 UI 层迁移到 worker/engine 层，并通过进度信号传播计算得到的 ETA，实现与 UI 层的解耦。

增强内容：
- 统一核心层和 UI 层的导入路径，在 `danmaku_sender` 命名空间下使用绝对包路径。
- 扩展在 worker、controller 和 UI 组件之间的发送进度信号，使其包含 ETA 秒数，从而在 `DelayManager` 中实现集中化的延迟和 ETA 管理。
- 在 `DelayManager` 中引入可复用的 `calc_eta` 辅助函数，用于根据节奏（pacing）配置计算剩余发送时间，并在后台发送 worker 中使用该函数来替代原先在 UI 层的逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple ETA calculation for danmaku sending from the UI layer by moving it into the worker/engine layer and propagating the computed ETA through progress signals.

Enhancements:
- Standardize core and UI imports to use absolute package paths under the danmaku_sender namespace.
- Extend sender progress signaling across worker, controller, and UI components to include ETA seconds, enabling centralized delay and ETA management within DelayManager.
- Introduce a reusable calc_eta helper in DelayManager to compute remaining send time based on pacing configuration and use it in the background send worker instead of UI-level logic.

</details>