### PR TITLE
refactor(ui): 补全缺失的 @Slot() 装饰器

### DIFF
--- a/src/danmaku_sender/ui/controllers/system_controller.py
+++ b/src/danmaku_sender/ui/controllers/system_controller.py
@@ -1,6 +1,6 @@
 import logging
 
-from PySide6.QtCore import QObject, Signal, QThreadPool
+from PySide6.QtCore import QObject, Signal, Slot, QThreadPool
 
 from ..framework.concurrency import GenericTask
 from ...api.update_checker import UpdateChecker, UpdateInfo
@@ -45,6 +45,7 @@ class SystemController(QObject):
 
         QThreadPool.globalInstance().start(task)
 
+    @Slot(object)
     def _on_check_finished(self, info: UpdateInfo):
         """内部回调：更新检查成功完成"""
         is_manual = self._in_flight_is_manual
@@ -58,6 +59,7 @@ class SystemController(QObject):
         else:
             self.updateNotFound.emit(is_manual)
 
+    @Slot(str)
     def _on_check_failed(self, err: str):
         """内部回调：更新检查失败"""
         is_manual = self._in_flight_is_manual

--- a/src/danmaku_sender/ui/dialogs.py
+++ b/src/danmaku_sender/ui/dialogs.py
@@ -275,6 +275,7 @@ class QRLoginDialog(QDialog):
         self.auth_controller.qrLoginSucceeded.connect(self._on_login_succeeded)
         self.auth_controller.qrLoginFailed.connect(self._on_login_failed)
 
+    @Slot(str)
     def _render_qr_code(self, url: str):
         """将 URL 转换为 Qt 图像"""
         try:

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -155,6 +155,7 @@ class ValidationRulesGroup(QGroupBox):
             lambda val: self.keywords_input.setEnabled(bool(val))
         )
 
+    @Slot(str)
     def _on_keywords_changed(self, text: str):
         """处理关键词文本变更"""
         if not self._state:
@@ -350,6 +351,7 @@ class PropertyInspectorGroup(QGroupBox):
         self.setEnabled(False)
         self.editor_widget.clear_form()
 
+    @Slot()
     def _on_save_clicked(self):
         props = self.editor_widget.get_properties()
         if not props[EditorField.MSG]:

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -96,6 +96,7 @@ class HistoryPage(QWidget):
         self._state = state
         self._refresh_table()
 
+    @Slot()
     def _refresh_table(self):
         """发起异步刷新请求"""
         keyword = self._search_input.text().strip()

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -2,7 +2,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QLineEdit,
     QCheckBox, QGroupBox, QPushButton, QDialog
 )
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, Slot
 
 from .framework.binder import UIBinder
 from .framework.style_loader import get_svg_icon
@@ -110,6 +110,7 @@ class SettingsPage(QWidget):
         UIBinder.bind(self.prevent_sleep_checkbox, state.monitor_config, "prevent_sleep", clear_old=False)
         UIBinder.bind(self.proxy_checkbox, state.monitor_config, "use_system_proxy", clear_old=False)
 
+    @Slot()
     def _open_qr_login(self):
         if not self._state:
             return


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- 为各类 UI 回调方法添加 `@Slot` 装饰器，使系统控制器、编辑器组件、对话框、历史记录页面和设置页面中的 Qt 信号-槽签名保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add @Slot decorators to various UI callback methods to align Qt signal-slot signatures across system controller, editor components, dialogs, history page, and settings page.

</details>