### PR TITLE
refactor(ui): DanmakuParser 改为局部实例化，消除跨线程复用隐患

### DIFF
--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -32,8 +32,6 @@ class SenderPage(QWidget):
         super().__init__()
         self._state: AppState | None = None
         self.logger = logging.getLogger("App.Sender.UI")
-        self.danmaku_parser = DanmakuParser()
-
         self._pending_part_index: int | None = None
         self.video_controller = VideoController(self)
         self.sender_controller = SenderController(self)
@@ -133,7 +131,7 @@ class SenderPage(QWidget):
         self.logger.info(f"📥 正在解析文件: {Path(file_path).name}")
         self.basic_group.file_input.setEnabled(False)
 
-        task = GenericTask(self.danmaku_parser.parse_xml_file, file_path)
+        task = GenericTask(DanmakuParser().parse_xml_file, file_path)
         task.signals.result.connect(lambda parsed: self._on_xml_parse_success(parsed, file_path))
         task.signals.error.connect(lambda err: self._on_xml_parse_error(str(err), file_path))
         QThreadPool.globalInstance().start(task)


### PR DESCRIPTION
SenderPage.__init__ 中长期持有的 danmaku_parser 实例被传入 GenericTask worker 线程，虽然当前无状态所以安全，但未来添加实例属性会立即产生线程安全 问题。改为与 editor_controller 一致的每次调用局部新建模式。

## Summary by Sourcery

增强：
- 在每次调用 `GenericTask` 时在本地实例化 `DanmakuParser`，而不是将其作为持久的 `SenderPage` 属性存储，以提高线程安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Instantiate DanmakuParser locally for each GenericTask invocation instead of storing it as a persistent SenderPage attribute to improve thread-safety.

</details>