### PR TITLE
refactor(sender): XML 解析任务从 SenderPage 下沉到 SenderController

### DIFF
--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -1,9 +1,9 @@
 import logging
 import threading
 
-from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtCore import QObject, Signal, Slot, QThreadPool
 
-from danmaku_sender.ui.framework.concurrency import BaseWorker
+from danmaku_sender.ui.framework.concurrency import BaseWorker, GenericTask
 
 from danmaku_sender.core.database.history_manager import HistoryManager
 from danmaku_sender.core.engines.sender import DanmakuScheduler, DanmakuExecutor, SendingContext, SendJob
@@ -11,7 +11,8 @@ from danmaku_sender.core.engines.sender.delay_manager import DelayManager
 from danmaku_sender.core.entities.danmaku import Danmaku
 from danmaku_sender.core.types.result import DanmakuSendResult
 from danmaku_sender.core.types.common import VideoTarget
-from danmaku_sender.core.state import ApiAuthConfig, SenderConfig
+from danmaku_sender.core.state import ApiAuthConfig, SenderConfig, AppState
+from danmaku_sender.core.services.danmaku_parser import DanmakuParser
 from danmaku_sender.api.bili_api_client import BiliApiClient
 from danmaku_sender.utils.system_utils import KeepSystemAwake
 
@@ -23,11 +24,17 @@ class SenderController(QObject):
     """发送任务业务控制器"""
     progressUpdated = Signal(int, int, float)
     taskFinished = Signal(object)
+    xmlParsed = Signal(str, int)          # file_path, danmaku_count
+    xmlParseFailed = Signal(str, object)  # file_path, raw_exception
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._state: AppState | None = None
         self._worker: SendTaskWorker | None = None
         self._stop_event = threading.Event()
+
+    def bind_state(self, state: AppState):
+        self._state = state
 
     def start_task(
         self,
@@ -71,6 +78,15 @@ class SenderController(QObject):
         """检查任务是否被手动中断"""
         return self._stop_event.is_set()
 
+    def load_xml_file(self, file_path: str):
+        """异步解析 XML 弹幕文件"""
+        self._state.video_state.loaded_danmakus = []
+        parser = DanmakuParser()
+        task = GenericTask(parser.parse_xml_file, file_path)
+        task.signals.result.connect(lambda parsed: self._on_parse_success(parsed, file_path))
+        task.signals.error.connect(lambda err: self._on_parse_error(err, file_path))
+        QThreadPool.globalInstance().start(task)
+
 
     # region Slots
 
@@ -85,6 +101,16 @@ class SenderController(QObject):
         if self._worker is not None:
             logger.debug("SendTaskWorker 线程生命周期结束，正在清理控制器引用。")
             self._worker = None
+
+    @Slot(list, str)
+    def _on_parse_success(self, parsed: list, file_path: str):
+        if parsed:
+            self._state.video_state.loaded_danmakus = parsed
+        self.xmlParsed.emit(file_path, len(parsed))
+
+    @Slot(object, str)
+    def _on_parse_error(self, err: Exception, file_path: str):
+        self.xmlParseFailed.emit(file_path, err)
 
     # endregion
 

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -20,7 +20,6 @@ from danmaku_sender.core.engines.sender.context import SendingContext
 from danmaku_sender.core.entities.video import VideoInfo
 from danmaku_sender.core.types.common import VideoTarget
 from danmaku_sender.core.services.danmaku_exporter import UnsentDanmakusRecord, create_xml_from_danmakus
-from danmaku_sender.core.services.danmaku_parser import DanmakuParser
 from danmaku_sender.core.state import AppState
 from danmaku_sender.utils.string_utils import parse_bilibili_link
 from danmaku_sender.utils.time_utils import format_duration
@@ -107,6 +106,8 @@ class SenderPage(QWidget):
         # SenderController
         self.sender_controller.progressUpdated.connect(self._on_send_progress)
         self.sender_controller.taskFinished.connect(self._on_send_finished)
+        self.sender_controller.xmlParsed.connect(self._on_xml_parsed)
+        self.sender_controller.xmlParseFailed.connect(self._on_xml_parse_failed)
 
     def bind_state(self, state: AppState):
         """将 UI 控件与 AppState 进行双向绑定"""
@@ -114,6 +115,7 @@ class SenderPage(QWidget):
             return
 
         self._state = state
+        self.sender_controller.bind_state(state)
 
         self.basic_group.bind_state(state)
         self.strategy_tabs.bind_state(state)
@@ -127,32 +129,26 @@ class SenderPage(QWidget):
         if not self._state:
             return
 
-        self._state.video_state.loaded_danmakus = []
         self.logger.info(f"📥 正在解析文件: {Path(file_path).name}")
         self.basic_group.file_input.setEnabled(False)
+        self.sender_controller.load_xml_file(file_path)
 
-        task = GenericTask(DanmakuParser().parse_xml_file, file_path)
-        task.signals.result.connect(lambda parsed: self._on_xml_parse_success(parsed, file_path))
-        task.signals.error.connect(lambda err: self._on_xml_parse_error(str(err), file_path))
-        QThreadPool.globalInstance().start(task)
-
-    @Slot(list, str)
-    def _on_xml_parse_success(self, parsed: list, file_path: str):
+    @Slot(str, int)
+    def _on_xml_parsed(self, file_path: str, count: int):
         self.basic_group.file_input.setEnabled(True)
-        if parsed:
+        if count > 0:
             self.basic_group.file_input.setText(Path(file_path).name)
-            self._state.video_state.loaded_danmakus = parsed
-            self.logger.info(f"✅ 文件解析成功，共 {len(parsed)} 条弹幕。")
+            self.logger.info(f"✅ 文件解析成功，共 {count} 条弹幕。")
         else:
             self.basic_group.file_input.clear()
             self.logger.warning("⚠️ 文件解析完成但无有效弹幕。")
 
-    @Slot(str, str)
-    def _on_xml_parse_error(self, err: str, file_path: str):
+    @Slot(str, object)
+    def _on_xml_parse_failed(self, file_path: str, err: Exception):
         self.basic_group.file_input.setEnabled(True)
         self.basic_group.file_input.clear()
-        self.logger.error(f"❌ 解析失败: {err}")
-        QMessageBox.critical(self, "解析失败", err)
+        self.logger.error(f"❌ 解析失败: {str(err)}")
+        QMessageBox.critical(self, "解析失败", str(err))
 
 
     # region Slots


### PR DESCRIPTION
SenderPage 直接管理 GenericTask 违反 MVC 分层。将 XML 解析的异步调度、 状态写入（loaded_danmakus）移入 SenderController，UI 层仅通过信号订阅 结果。对齐 VideoController 的信号广播模式。

## Summary by Sourcery

将 XML 弹幕文件的解析从 SenderPage 界面重构到 SenderController 中，使 XML 加载流程与基于控制器的工作流及基于信号的更新机制保持一致。

Enhancements:
- 将用于解析弹幕 XML 文件及调度异步任务的逻辑，从 SenderPage 迁移到 SenderController，在控制器内部更新 `video_state.loaded_danmakus`。
- 在 SenderController 中引入 `xmlParsed` 和 `xmlParseFailed` 信号，并将 SenderPage 连接到这些信号，使其仅通过信号对解析结果做出响应，同时将状态管理职责委托给控制器。
- 为 SenderController 增加状态绑定，使其在处理 XML 加载操作时可以直接管理 `AppState`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor XML danmaku file parsing from the SenderPage UI into SenderController, aligning XML loading with the controller-driven workflow and signal-based updates.

Enhancements:
- Move XML parsing and asynchronous task scheduling for danmaku files from SenderPage into SenderController, updating video_state.loaded_danmakus within the controller.
- Introduce xmlParsed and xmlParseFailed signals on SenderController and wire SenderPage to react to parse results purely via signals while delegating state management to the controller.
- Add state binding to SenderController so it can manage AppState directly when handling XML load operations.

</details>