### PR TITLE
refactor(controller): 重构 video_controller 批量获取，使用标准信号桥接替代直接 emit 回调

### DIFF
--- a/src/danmaku_sender/ui/controllers/video_controller.py
+++ b/src/danmaku_sender/ui/controllers/video_controller.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Callable
 
 from PySide6.QtCore import QObject, Signal, QThreadPool, Slot
 
@@ -28,22 +27,24 @@ def _fetch_single_video_info(bvid: str, auth_config: ApiAuthConfig) -> VideoInfo
 
 def _fetch_multiple_video_infos(
     bvids: list[str],
-    auth_config: ApiAuthConfig,
-    on_succeeded: Callable[[str, VideoInfo], None],
-    on_failed: Callable[[str, Exception], None]
-):
+    auth_config: ApiAuthConfig
+) -> list[tuple[str, VideoInfo | Exception]]:
     """
     复用底层连接 (Keep-Alive) 获取多个视频信息。
-    通过回调函数实现结果的流式输出
+
+    Returns:
+        包含 (bvid, result) 元组的列表，其中 result 是 VideoInfo 或 Exception
     """
+    results = []
     with BiliApiClient.from_config(auth_config) as client:
         service = VideoFetcher(client)
         for bvid in bvids:
             try:
                 info = service.fetch_info(bvid)
-                on_succeeded(bvid, info)
+                results.append((bvid, info))
             except Exception as e:
-                on_failed(bvid, e)
+                results.append((bvid, e))
+    return results
 
 
 class VideoController(QObject):
@@ -97,19 +98,22 @@ class VideoController(QObject):
 
     def fetch_multiple_infos(self, bvids: list[str], auth_config: ApiAuthConfig):
         """
-        静默获取多条视频信息 (流式返回)
+        静默获取多条视频信息 (批量返回)
 
         调用此方法会自动进入后台专有队列，且享有 HTTP Keep-Alive 性能加成。
         """
         if not bvids:
             return
 
-        task = GenericTask(
-            _fetch_multiple_video_infos,
-            bvids,
-            auth_config,
-            self.fetchSucceeded.emit,
-            self.fetchFailed.emit
-        )
+        task = GenericTask(_fetch_multiple_video_infos, bvids, auth_config)
 
+        @Slot(list)
+        def _on_fetch_completed(results: list[tuple[str, VideoInfo | Exception]]):
+            for bvid, result in results:
+                if isinstance(result, Exception):
+                    self.fetchFailed.emit(bvid, result)
+                else:
+                    self.fetchSucceeded.emit(bvid, result)
+
+        task.signals.result.connect(_on_fetch_completed)
         _bg_fetch_pool.start(task)


### PR DESCRIPTION
## Summary by Sourcery

重构批量视频信息获取逻辑，使其返回聚合结果，并通过现有的 Qt 信号进行桥接，而不是直接从 worker 中触发回调。

增强点：
- 将 `_fetch_multiple_video_infos` 修改为返回由 `(bvid, VideoInfo | Exception)` 元组组成的列表，而不是为每个条目分别调用成功/失败回调。
- 更新 `VideoController.fetch_multiple_infos`，在 Qt 槽中处理聚合结果，并通过标准任务结果信号桥接机制，为每个视频分别发出 `fetchSucceeded` / `fetchFailed` 信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor batch video info fetching to return aggregated results and bridge them to existing Qt signals instead of emitting callbacks directly from the worker.

Enhancements:
- Change _fetch_multiple_video_infos to return a list of (bvid, VideoInfo | Exception) tuples instead of invoking success/failure callbacks per item.
- Update VideoController.fetch_multiple_infos to handle the aggregated results in a Qt slot and emit fetchSucceeded/fetchFailed signals per video via the standard task result signal bridge.

</details>