### PR TITLE
refactor(ui): 构造函数注入 AppState，消除全局 None 检查

### DIFF
--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -29,7 +29,7 @@ class SenderController(QObject):
 
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
-        self._state = state
+        self.state = state
         self._worker: SendTaskWorker | None = None
         self._stop_event = threading.Event()
 
@@ -77,7 +77,7 @@ class SenderController(QObject):
 
     def load_xml_file(self, file_path: str):
         """异步解析 XML 弹幕文件"""
-        self._state.video_state.loaded_danmakus = []
+        self.state.video_state.loaded_danmakus = []
         parser = DanmakuParser()
         task = GenericTask(parser.parse_xml_file, file_path)
         task.signals.result.connect(lambda parsed: self._on_parse_success(parsed, file_path))
@@ -102,7 +102,7 @@ class SenderController(QObject):
     @Slot(list, str)
     def _on_parse_success(self, parsed: list, file_path: str):
         if parsed:
-            self._state.video_state.loaded_danmakus = parsed
+            self.state.video_state.loaded_danmakus = parsed
         self.xmlParsed.emit(file_path, len(parsed))
 
     @Slot(object, str)

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -27,14 +27,11 @@ class SenderController(QObject):
     xmlParsed = Signal(str, int)          # file_path, danmaku_count
     xmlParseFailed = Signal(str, object)  # file_path, raw_exception
 
-    def __init__(self, parent=None):
+    def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
-        self._state: AppState | None = None
+        self._state = state
         self._worker: SendTaskWorker | None = None
         self._stop_event = threading.Event()
-
-    def bind_state(self, state: AppState):
-        self._state = state
 
     def start_task(
         self,

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -125,9 +125,9 @@ class ValidationRulesGroup(QGroupBox):
 
         layout.addLayout(keyword_layout)
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        config = state.validation_config
+        config = self._state.validation_config
 
         # 通用控件绑定
         UIBinder.bind(self.enable_custom_checkbox, config, "enabled")

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -147,9 +147,6 @@ class ValidationRulesGroup(QGroupBox):
     @Slot(str)
     def _on_keywords_changed(self, text: str):
         """处理关键词文本变更"""
-        if not self.state:
-            return
-
         raw_text = text.replace('，', ',').lower()
         parts = [k.strip() for k in raw_text.split(',') if k.strip()]
         unique_keywords = sorted(list(set(parts)))

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -99,10 +99,10 @@ class EditorTableModel(QAbstractTableModel):
 
 class ValidationRulesGroup(QGroupBox):
     """校验与过滤规则区"""
-    def __init__(self, parent=None):
+    def __init__(self, state: AppState, parent=None):
         super().__init__("校验与过滤规则", parent)
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
-        self._state: AppState | None = None
+        self._state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -127,17 +127,6 @@ class ValidationRulesGroup(QGroupBox):
 
     def bind_state(self, state: AppState):
         """将 UI 控件与 AppState 进行双向绑定"""
-        if self._state is state:
-            return
-
-        if self._state is not None:
-            try:
-                self.keywords_input.textChanged.disconnect()
-                self.enable_custom_checkbox.stateChanged.disconnect()
-            except (RuntimeError, TypeError):
-                pass
-
-        self._state = state
         config = state.validation_config
 
         # 通用控件绑定

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -102,7 +102,7 @@ class ValidationRulesGroup(QGroupBox):
     def __init__(self, state: AppState, parent=None):
         super().__init__("校验与过滤规则", parent)
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
-        self._state = state
+        self.state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -125,9 +125,9 @@ class ValidationRulesGroup(QGroupBox):
 
         layout.addLayout(keyword_layout)
 
-    def bind_state(self):
+    def _init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        config = self._state.validation_config
+        config = self.state.validation_config
 
         # 通用控件绑定
         UIBinder.bind(self.enable_custom_checkbox, config, "enabled")
@@ -147,14 +147,14 @@ class ValidationRulesGroup(QGroupBox):
     @Slot(str)
     def _on_keywords_changed(self, text: str):
         """处理关键词文本变更"""
-        if not self._state:
+        if not self.state:
             return
 
         raw_text = text.replace('，', ',').lower()
         parts = [k.strip() for k in raw_text.split(',') if k.strip()]
         unique_keywords = sorted(list(set(parts)))
 
-        self._state.validation_config.blocked_keywords = unique_keywords
+        self.state.validation_config.blocked_keywords = unique_keywords
 
 
 class DanmakuPropertyForm(QWidget):

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -21,14 +21,15 @@ from ...core.services.danmaku_exporter import export_danmakus_to_xml
 
 
 class EditorPage(QWidget):
-    def __init__(self):
+    def __init__(self, state: AppState):
         super().__init__()
-        self.controller: EditorController | None = None
+        self.controller = EditorController(state, self)
         self.logger = logging.getLogger("App.System.UI.Editor")
 
         self.current_item_id: str | None = None
 
         self._create_ui()
+        self.controller.dataChanged.connect(self._refresh_table)
 
     # region UI Setup & Data Binding
     def _create_ui(self):
@@ -104,7 +105,7 @@ class EditorPage(QWidget):
         main_layout.addLayout(toolbar_layout)
 
         # --- 规则管理区 ---
-        self.rules_group = ValidationRulesGroup()
+        self.rules_group = ValidationRulesGroup(self.controller.state)
         main_layout.addWidget(self.rules_group)
 
         # --- 核心区 ---
@@ -179,12 +180,6 @@ class EditorPage(QWidget):
 
     def bind_state(self, state: AppState):
         """将 UI 控件与 AppState 进行双向绑定"""
-        if self.controller and self.controller.state is state:
-            return
-
-        self.controller = EditorController(state, self)
-        self.controller.dataChanged.connect(self._refresh_table)
-
         self.rules_group.bind_state(state)
         self._update_ui_state()
 

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -178,9 +178,9 @@ class EditorPage(QWidget):
 
         self._update_ui_state()
 
-    def bind_state(self):
+    def _init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.rules_group.bind_state()
+        self.rules_group._init_bindings()
         self._update_ui_state()
 
     # endregion

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -178,9 +178,9 @@ class EditorPage(QWidget):
 
         self._update_ui_state()
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.rules_group.bind_state(state)
+        self.rules_group.bind_state()
         self._update_ui_state()
 
     # endregion

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -21,9 +21,9 @@ logger = logging.getLogger("App.System.UI.History")
 
 
 class HistoryPage(QWidget):
-    def __init__(self):
+    def __init__(self, state: AppState):
         super().__init__()
-        self._state: AppState | None = None
+        self._state = state
         self._fetched_bvids = set()
 
         self.video_controller = VideoController(self)
@@ -93,7 +93,6 @@ class HistoryPage(QWidget):
         self.history_controller.errorOccurred.connect(self._on_history_query_failed)
 
     def bind_state(self, state: AppState):
-        self._state = state
         self._refresh_table()
 
     @Slot()

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -92,7 +92,7 @@ class HistoryPage(QWidget):
         self.history_controller.historyFetched.connect(self._on_history_query_succeeded)
         self.history_controller.errorOccurred.connect(self._on_history_query_failed)
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         self._refresh_table()
 
     @Slot()

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("App.System.UI.History")
 class HistoryPage(QWidget):
     def __init__(self, state: AppState):
         super().__init__()
-        self._state = state
+        self.state = state
         self._fetched_bvids = set()
 
         self.video_controller = VideoController(self)
@@ -92,7 +92,7 @@ class HistoryPage(QWidget):
         self.history_controller.historyFetched.connect(self._on_history_query_succeeded)
         self.history_controller.errorOccurred.connect(self._on_history_query_failed)
 
-    def bind_state(self):
+    def _init_bindings(self):
         self._refresh_table()
 
     @Slot()
@@ -107,10 +107,10 @@ class HistoryPage(QWidget):
 
     def _fetch_missing_metadata(self, records):
         """扫描缺失元数据的 BVID 并推入后台队列"""
-        if not self._state:
+        if not self.state:
             return
 
-        auth_config = self._state.get_api_auth()
+        auth_config = self.state.get_api_auth()
         missing_bvids = []
         for row in records:
             bvid = row['bvid']
@@ -161,7 +161,7 @@ class HistoryPage(QWidget):
         将结果刷入表格，并触发缺失元数据的后台补全。
         """
         self._model.set_records(records)
-        if self._state:
+        if self.state:
             self._fetch_missing_metadata(records)
 
     @Slot(object)

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -107,9 +107,6 @@ class HistoryPage(QWidget):
 
     def _fetch_missing_metadata(self, records):
         """扫描缺失元数据的 BVID 并推入后台队列"""
-        if not self.state:
-            return
-
         auth_config = self.state.get_api_auth()
         missing_bvids = []
         for row in records:

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -278,11 +278,11 @@ class MainWindow(QMainWindow):
     def _bind_state_to_pages(self):
         """绑定全局状态并配置日志路由"""
         # 页面数据绑定
-        self.page_settings.bind_state(self.state)
-        self.page_sender.bind_state(self.state)
-        self.page_editor.bind_state(self.state)
-        self.page_monitor.bind_state(self.state)
-        self.page_history.bind_state(self.state)
+        self.page_settings.bind_state()
+        self.page_sender.bind_state()
+        self.page_editor.bind_state()
+        self.page_monitor.bind_state()
+        self.page_history.bind_state()
 
         # 日志分流：信号 -> Tab 接口
         if self._log_signals_connected:

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -170,11 +170,11 @@ class MainWindow(QMainWindow):
 
     def _init_pages(self):
         """初始化页面并绑定导航"""
-        self.page_settings = SettingsPage()
-        self.page_sender = SenderPage()
-        self.page_editor = EditorPage()
-        self.page_monitor = MonitorPage()
-        self.page_history = HistoryPage()
+        self.page_settings = SettingsPage(self.state)
+        self.page_sender = SenderPage(self.state)
+        self.page_editor = EditorPage(self.state)
+        self.page_monitor = MonitorPage(self.state)
+        self.page_history = HistoryPage(self.state)
 
         # 定义页面列表
         pages = [

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -278,11 +278,11 @@ class MainWindow(QMainWindow):
     def _bind_state_to_pages(self):
         """绑定全局状态并配置日志路由"""
         # 页面数据绑定
-        self.page_settings.bind_state()
-        self.page_sender.bind_state()
-        self.page_editor.bind_state()
-        self.page_monitor.bind_state()
-        self.page_history.bind_state()
+        self.page_settings._init_bindings()
+        self.page_sender._init_bindings()
+        self.page_editor._init_bindings()
+        self.page_monitor._init_bindings()
+        self.page_history._init_bindings()
 
         # 日志分流：信号 -> Tab 接口
         if self._log_signals_connected:

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -211,9 +211,6 @@ class MonitorPage(QWidget):
             self.anchor_display.setText(dt_str)
 
     def _refresh_info_labels(self):
-        if not self.state:
-            return
-
         video_state = self.state.video_state
 
         if video_state.selected_cid:
@@ -237,8 +234,7 @@ class MonitorPage(QWidget):
         self.interval_spin.setEnabled(not running)
         self.start_btn.setEnabled(True)
 
-        if self.state:
-            self.state.monitor_is_active = running
+        self.state.monitor_is_active = running
 
         if running:
             self.start_btn.setText("停止监视")
@@ -254,9 +250,6 @@ class MonitorPage(QWidget):
     # region Slots Internal
     @Slot()
     def _toggle_task(self):
-        if not self.state:
-            return
-
         if self.monitor_controller.is_running():
             self.monitor_controller.stop_task()
             self.start_btn.setText("正在停止...")
@@ -286,7 +279,7 @@ class MonitorPage(QWidget):
 
     @Slot(int)
     def _on_anchor_changed(self, index: int):
-        if not self.state or index < 0:
+        if index < 0:
             return
 
         data = self.anchor_combo.currentData()
@@ -303,9 +296,6 @@ class MonitorPage(QWidget):
 
     @Slot()
     def _on_reset_anchor_clicked(self):
-        if not self.state:
-            return
-
         current_ts = time.time()
         self.state.monitor_config.stats_baseline = current_ts
         self._update_anchor_display(current_ts)

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -176,9 +176,9 @@ class MonitorPage(QWidget):
         self.monitor_controller.statusUpdated.connect(self.status_label.setText)
         self.monitor_controller.taskFinished.connect(self._on_finished)
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         # 初始化与绑定
-        UIBinder.bind(self.interval_spin, state.monitor_config, "refresh_interval")
+        UIBinder.bind(self.interval_spin, self._state.monitor_config, "refresh_interval")
 
         if self._state.monitor_config.stats_baseline == 0.0:
             self._state.monitor_config.stats_baseline = self._state.app_launch_time

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -18,9 +18,9 @@ from ..core.types.common import VideoTarget, MonitorStats
 
 
 class MonitorPage(QWidget):
-    def __init__(self):
+    def __init__(self, state: AppState):
         super().__init__()
-        self._state = None
+        self._state = state
         self.logger = logging.getLogger("App.Monitor.UI")
 
         self.monitor_controller = MonitorController(self)
@@ -177,11 +177,6 @@ class MonitorPage(QWidget):
         self.monitor_controller.taskFinished.connect(self._on_finished)
 
     def bind_state(self, state: AppState):
-        if self._state is state:
-            return
-
-        self._state = state
-
         # 初始化与绑定
         UIBinder.bind(self.interval_spin, state.monitor_config, "refresh_interval")
 

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -20,7 +20,7 @@ from ..core.types.common import VideoTarget, MonitorStats
 class MonitorPage(QWidget):
     def __init__(self, state: AppState):
         super().__init__()
-        self._state = state
+        self.state = state
         self.logger = logging.getLogger("App.Monitor.UI")
 
         self.monitor_controller = MonitorController(self)
@@ -176,12 +176,12 @@ class MonitorPage(QWidget):
         self.monitor_controller.statusUpdated.connect(self.status_label.setText)
         self.monitor_controller.taskFinished.connect(self._on_finished)
 
-    def bind_state(self):
+    def _init_bindings(self):
         # 初始化与绑定
-        UIBinder.bind(self.interval_spin, self._state.monitor_config, "refresh_interval")
+        UIBinder.bind(self.interval_spin, self.state.monitor_config, "refresh_interval")
 
-        if self._state.monitor_config.stats_baseline == 0.0:
-            self._state.monitor_config.stats_baseline = self._state.app_launch_time
+        if self.state.monitor_config.stats_baseline == 0.0:
+            self.state.monitor_config.stats_baseline = self.state.app_launch_time
 
             idx = self.anchor_combo.findData("launch")
             if idx >= 0:
@@ -189,7 +189,7 @@ class MonitorPage(QWidget):
                 self.anchor_combo.setCurrentIndex(idx)
                 self.anchor_combo.blockSignals(False)
 
-        self._update_anchor_display(self._state.monitor_config.stats_baseline)
+        self._update_anchor_display(self.state.monitor_config.stats_baseline)
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -211,10 +211,10 @@ class MonitorPage(QWidget):
             self.anchor_display.setText(dt_str)
 
     def _refresh_info_labels(self):
-        if not self._state:
+        if not self.state:
             return
 
-        video_state = self._state.video_state
+        video_state = self.state.video_state
 
         if video_state.selected_cid:
             info_parts = []
@@ -237,8 +237,8 @@ class MonitorPage(QWidget):
         self.interval_spin.setEnabled(not running)
         self.start_btn.setEnabled(True)
 
-        if self._state:
-            self._state.monitor_is_active = running
+        if self.state:
+            self.state.monitor_is_active = running
 
         if running:
             self.start_btn.setText("停止监视")
@@ -254,7 +254,7 @@ class MonitorPage(QWidget):
     # region Slots Internal
     @Slot()
     def _toggle_task(self):
-        if not self._state:
+        if not self.state:
             return
 
         if self.monitor_controller.is_running():
@@ -263,15 +263,15 @@ class MonitorPage(QWidget):
             self.start_btn.setEnabled(False)
             return
 
-        cid = self._state.video_state.selected_cid
-        bvid = self._state.video_state.bvid
-        title = self._state.video_state.video_title
+        cid = self.state.video_state.selected_cid
+        bvid = self.state.video_state.bvid
+        title = self.state.video_state.video_title
 
         if not cid:
             QMessageBox.warning(self, "无法启动", "请先在“发射器”页面获取视频信息并选择分P。\n(监视器需要 CID 来查询数据库)")
             return
 
-        if not self._state.sessdata:
+        if not self.state.sessdata:
             QMessageBox.warning(self, "凭证缺失", "请先配置 Cookie。")
             return
 
@@ -280,34 +280,34 @@ class MonitorPage(QWidget):
         target = VideoTarget(bvid=bvid, cid=cid, title=title)
         self.monitor_controller.start_task(
             target=target,
-            auth_config=self._state.get_api_auth(),
-            monitor_config=self._state.monitor_config
+            auth_config=self.state.get_api_auth(),
+            monitor_config=self.state.monitor_config
         )
 
     @Slot(int)
     def _on_anchor_changed(self, index: int):
-        if not self._state or index < 0:
+        if not self.state or index < 0:
             return
 
         data = self.anchor_combo.currentData()
         new_baseline = 0.0
         if data == "launch":
-            new_baseline = self._state.app_launch_time
+            new_baseline = self.state.app_launch_time
         elif data == "24h":
             new_baseline = time.time() - 86400
         elif data == "all":
             new_baseline = 0.0
 
-        self._state.monitor_config.stats_baseline = new_baseline
+        self.state.monitor_config.stats_baseline = new_baseline
         self._update_anchor_display(new_baseline)
 
     @Slot()
     def _on_reset_anchor_clicked(self):
-        if not self._state:
+        if not self.state:
             return
 
         current_ts = time.time()
-        self._state.monitor_config.stats_baseline = current_ts
+        self.state.monitor_config.stats_baseline = current_ts
         self._update_anchor_display(current_ts)
 
         self.anchor_combo.blockSignals(True)

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -29,7 +29,7 @@ from danmaku_sender.utils.notification_utils import send_windows_notification
 class SenderPage(QWidget):
     def __init__(self, state: AppState):
         super().__init__()
-        self._state = state
+        self.state = state
         self.logger = logging.getLogger("App.Sender.UI")
         self._pending_part_index: int | None = None
         self.video_controller = VideoController(self)
@@ -50,8 +50,8 @@ class SenderPage(QWidget):
         main_layout.setContentsMargins(10, 10, 10, 10)
 
         # --- 基础参数策略区 ---
-        self.basic_group = BasicParamsGroup(self._state)
-        self.strategy_tabs = StrategySettingsTabs(self._state)
+        self.basic_group = BasicParamsGroup(self.state)
+        self.strategy_tabs = StrategySettingsTabs(self.state)
 
         main_layout.addWidget(self.basic_group)
         main_layout.addWidget(self.strategy_tabs)
@@ -109,10 +109,10 @@ class SenderPage(QWidget):
         self.sender_controller.xmlParsed.connect(self._on_xml_parsed)
         self.sender_controller.xmlParseFailed.connect(self._on_xml_parse_failed)
 
-    def bind_state(self):
+    def _init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.basic_group.bind_state()
-        self.strategy_tabs.bind_state()
+        self.basic_group._init_bindings()
+        self.strategy_tabs._init_bindings()
 
     def append_log(self, message: str):
         """外部调用的日志接口"""
@@ -120,7 +120,7 @@ class SenderPage(QWidget):
         self.log_output.moveCursor(QTextCursor.MoveOperation.End)
 
     def _load_xml_file(self, file_path: str):
-        if not self._state:
+        if not self.state:
             return
 
         self.logger.info(f"📥 正在解析文件: {Path(file_path).name}")
@@ -150,7 +150,7 @@ class SenderPage(QWidget):
     @Slot()
     def _select_file(self):
         """文件选择逻辑"""
-        if not self._state:
+        if not self.state:
             return
 
         file_path, _ = QFileDialog.getOpenFileName(self, "选择弹幕XML文件", "", "XML Files (*.xml);;All Files (*.*)")
@@ -160,7 +160,7 @@ class SenderPage(QWidget):
     @Slot()
     def _fetch_video_info(self):
         """UI 层: 负责获取参数，下发指令"""
-        if not self._state:
+        if not self.state:
             return
 
         raw_input = self.basic_group.bv_input.text().strip()
@@ -177,12 +177,12 @@ class SenderPage(QWidget):
         self.basic_group.bv_input.setText(bvid)
         self._pending_part_index = p_index
 
-        self.video_controller.fetch_single_info(bvid, self._state.get_api_auth())
+        self.video_controller.fetch_single_info(bvid, self.state.get_api_auth())
 
     @Slot(int)
     def _on_part_selected(self, index: int):
         """处理分P选择变化"""
-        if not self._state:
+        if not self.state:
             return
 
         if index < 0:
@@ -196,15 +196,15 @@ class SenderPage(QWidget):
         duration = data['duration']
         part_name = self.basic_group.part_combo.currentText()
 
-        self._state.video_state.selected_cid = cid
-        self._state.video_state.selected_part_duration_ms = duration * 1000
-        self._state.video_state.selected_part_name = part_name
+        self.state.video_state.selected_cid = cid
+        self.state.video_state.selected_part_duration_ms = duration * 1000
+        self.state.video_state.selected_part_name = part_name
         self.logger.info(f"已选择分P: {part_name} (CID: {cid})")
 
     @Slot()
     def _toggle_task(self):
         """开始/停止 任务"""
-        if not self._state:
+        if not self.state:
             return
 
         # 如果正在运行 -> 停止
@@ -218,7 +218,7 @@ class SenderPage(QWidget):
 
         # 如果未运行 -> 开始
         # 校验
-        state = self._state
+        state = self.state
 
         if state.editor_is_dirty:
             QMessageBox.warning(
@@ -265,15 +265,15 @@ class SenderPage(QWidget):
     @Slot(str, VideoInfo)
     def _on_fetch_succeeded(self, bvid: str, info: VideoInfo):
         """获取成功: 解析分P并允许用户选择"""
-        if not self._state:
+        if not self.state:
             return
 
         self.basic_group.fetch_btn.setEnabled(True)
         self.basic_group.fetch_btn.setText("获取分P")
         self.basic_group.part_combo.setEnabled(True)
 
-        self._state.video_state.video_title = info.title
-        self._state.video_state.cid_parts_map = {}
+        self.state.video_state.video_title = info.title
+        self.state.video_state.cid_parts_map = {}
 
         self.logger.info(f"获取成功: {info.title}, 共 {len(info.parts)} 个分P")
 
@@ -284,7 +284,7 @@ class SenderPage(QWidget):
             part_name = f"P{p.page} - {p.title}"
 
             self.basic_group.part_combo.addItem(part_name, userData={'cid': p.cid, 'duration': p.duration})
-            self._state.video_state.cid_parts_map[p.cid] = part_name
+            self.state.video_state.cid_parts_map[p.cid] = part_name
 
         if info.parts:
             if (self._pending_part_index is not None and
@@ -410,8 +410,8 @@ class SenderPage(QWidget):
     def _set_ui_for_task_start(self):
         """任务开始时的 UI 状态设置"""
         # 通知全局状态
-        if self._state:
-            self._state.sender_is_active = True
+        if self.state:
+            self.state.sender_is_active = True
 
         # 按钮变红
         self.start_btn.setText("紧急停止")
@@ -427,8 +427,8 @@ class SenderPage(QWidget):
     def _reset_ui_after_task(self):
         """任务结束后的 UI 状态复位"""
         # 通知全局状态
-        if self._state:
-            self._state.sender_is_active = False
+        if self.state:
+            self.state.sender_is_active = False
 
         # 恢复按钮状态
         self.start_btn.setText("开始发送")
@@ -464,7 +464,7 @@ class SenderPage(QWidget):
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """鼠标拖拽文件进入页面区域"""
         # 如果当前正在发送弹幕则拒绝拖入
-        if self._state and self._state.sender_is_active:
+        if self.state and self.state.sender_is_active:
             event.ignore()
             return
 
@@ -480,7 +480,7 @@ class SenderPage(QWidget):
     def dropEvent(self, event: QDropEvent) -> None:
         """鼠标落下"""
         # 如果当前正在发送弹幕则拒绝拖入
-        if self._state and self._state.sender_is_active:
+        if self.state and self.state.sender_is_active:
             event.ignore()
             return
 
@@ -498,7 +498,7 @@ class BasicParamsGroup(QGroupBox):
     """基础参数区"""
     def __init__(self, state: AppState, parent=None):
         super().__init__("基础参数", parent)
-        self._state = state
+        self.state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -538,13 +538,13 @@ class BasicParamsGroup(QGroupBox):
         layout.addRow(QLabel("弹幕文件:"), file_layout)
         layout.addRow(QLabel(""), self.skip_sent_cb)
 
-    def bind_state(self):
+    def _init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        UIBinder.bind(self.bv_input, self._state.video_state, "bvid", realtime=True)
-        UIBinder.bind(self.skip_sent_cb, self._state.sender_config, "skip_sent")
+        UIBinder.bind(self.bv_input, self.state.video_state, "bvid", realtime=True)
+        UIBinder.bind(self.skip_sent_cb, self.state.sender_config, "skip_sent")
 
-        if self._state.video_state.selected_part_name:
-            self.part_combo.setPlaceholderText(self._state.video_state.selected_part_name)
+        if self.state.video_state.selected_part_name:
+            self.part_combo.setPlaceholderText(self.state.video_state.selected_part_name)
 
     def set_inputs_locked(self, locked: bool):
         """供主控调用的防误触锁"""
@@ -561,7 +561,7 @@ class StrategySettingsTabs(QTabWidget):
     """策略设置区"""
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
-        self._state = state
+        self.state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -653,9 +653,9 @@ class StrategySettingsTabs(QTabWidget):
 
         self.addTab(stop_tab, "自动终止")
 
-    def bind_state(self):
+    def _init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        config = self._state.sender_config
+        config = self.state.sender_config
 
         # 发送延迟策略
         UIBinder.bind(self.min_delay, config, "min_delay")

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -50,8 +50,8 @@ class SenderPage(QWidget):
         main_layout.setContentsMargins(10, 10, 10, 10)
 
         # --- 基础参数策略区 ---
-        self.basic_group = BasicParamsGroup()
-        self.strategy_tabs = StrategySettingsTabs()
+        self.basic_group = BasicParamsGroup(self._state)
+        self.strategy_tabs = StrategySettingsTabs(self._state)
 
         main_layout.addWidget(self.basic_group)
         main_layout.addWidget(self.strategy_tabs)
@@ -109,10 +109,10 @@ class SenderPage(QWidget):
         self.sender_controller.xmlParsed.connect(self._on_xml_parsed)
         self.sender_controller.xmlParseFailed.connect(self._on_xml_parse_failed)
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.basic_group.bind_state(state)
-        self.strategy_tabs.bind_state(state)
+        self.basic_group.bind_state()
+        self.strategy_tabs.bind_state()
 
     def append_log(self, message: str):
         """外部调用的日志接口"""
@@ -496,8 +496,9 @@ class SenderPage(QWidget):
 
 class BasicParamsGroup(QGroupBox):
     """基础参数区"""
-    def __init__(self, parent=None):
+    def __init__(self, state: AppState, parent=None):
         super().__init__("基础参数", parent)
+        self._state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -537,13 +538,13 @@ class BasicParamsGroup(QGroupBox):
         layout.addRow(QLabel("弹幕文件:"), file_layout)
         layout.addRow(QLabel(""), self.skip_sent_cb)
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        UIBinder.bind(self.bv_input, state.video_state, "bvid", realtime=True)
-        UIBinder.bind(self.skip_sent_cb, state.sender_config, "skip_sent")
+        UIBinder.bind(self.bv_input, self._state.video_state, "bvid", realtime=True)
+        UIBinder.bind(self.skip_sent_cb, self._state.sender_config, "skip_sent")
 
-        if state.video_state.selected_part_name:
-            self.part_combo.setPlaceholderText(state.video_state.selected_part_name)
+        if self._state.video_state.selected_part_name:
+            self.part_combo.setPlaceholderText(self._state.video_state.selected_part_name)
 
     def set_inputs_locked(self, locked: bool):
         """供主控调用的防误触锁"""
@@ -558,8 +559,9 @@ class BasicParamsGroup(QGroupBox):
 
 class StrategySettingsTabs(QTabWidget):
     """策略设置区"""
-    def __init__(self, parent=None):
+    def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
+        self._state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -651,9 +653,9 @@ class StrategySettingsTabs(QTabWidget):
 
         self.addTab(stop_tab, "自动终止")
 
-    def bind_state(self, state: AppState):
+    def bind_state(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        config = state.sender_config
+        config = self._state.sender_config
 
         # 发送延迟策略
         UIBinder.bind(self.min_delay, config, "min_delay")

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -120,9 +120,6 @@ class SenderPage(QWidget):
         self.log_output.moveCursor(QTextCursor.MoveOperation.End)
 
     def _load_xml_file(self, file_path: str):
-        if not self.state:
-            return
-
         self.logger.info(f"📥 正在解析文件: {Path(file_path).name}")
         self.basic_group.file_input.setEnabled(False)
         self.sender_controller.load_xml_file(file_path)
@@ -150,9 +147,6 @@ class SenderPage(QWidget):
     @Slot()
     def _select_file(self):
         """文件选择逻辑"""
-        if not self.state:
-            return
-
         file_path, _ = QFileDialog.getOpenFileName(self, "选择弹幕XML文件", "", "XML Files (*.xml);;All Files (*.*)")
         if file_path:
             self._load_xml_file(file_path)
@@ -160,9 +154,6 @@ class SenderPage(QWidget):
     @Slot()
     def _fetch_video_info(self):
         """UI 层: 负责获取参数，下发指令"""
-        if not self.state:
-            return
-
         raw_input = self.basic_group.bv_input.text().strip()
         if not raw_input:
             QMessageBox.warning(self, "输入错误", "请输入BV号或视频链接")
@@ -182,9 +173,6 @@ class SenderPage(QWidget):
     @Slot(int)
     def _on_part_selected(self, index: int):
         """处理分P选择变化"""
-        if not self.state:
-            return
-
         if index < 0:
             return
 
@@ -204,9 +192,6 @@ class SenderPage(QWidget):
     @Slot()
     def _toggle_task(self):
         """开始/停止 任务"""
-        if not self.state:
-            return
-
         # 如果正在运行 -> 停止
         if self.sender_controller.is_running():
             self.sender_controller.stop_task()
@@ -265,9 +250,6 @@ class SenderPage(QWidget):
     @Slot(str, VideoInfo)
     def _on_fetch_succeeded(self, bvid: str, info: VideoInfo):
         """获取成功: 解析分P并允许用户选择"""
-        if not self.state:
-            return
-
         self.basic_group.fetch_btn.setEnabled(True)
         self.basic_group.fetch_btn.setText("获取分P")
         self.basic_group.part_combo.setEnabled(True)

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -27,13 +27,13 @@ from danmaku_sender.utils.notification_utils import send_windows_notification
 
 
 class SenderPage(QWidget):
-    def __init__(self):
+    def __init__(self, state: AppState):
         super().__init__()
-        self._state: AppState | None = None
+        self._state = state
         self.logger = logging.getLogger("App.Sender.UI")
         self._pending_part_index: int | None = None
         self.video_controller = VideoController(self)
-        self.sender_controller = SenderController(self)
+        self.sender_controller = SenderController(state, self)
 
         self._create_ui()
         self._connect_signals()
@@ -111,12 +111,6 @@ class SenderPage(QWidget):
 
     def bind_state(self, state: AppState):
         """将 UI 控件与 AppState 进行双向绑定"""
-        if self._state is state:
-            return
-
-        self._state = state
-        self.sender_controller.bind_state(state)
-
         self.basic_group.bind_state(state)
         self.strategy_tabs.bind_state(state)
 

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -12,10 +12,10 @@ from ..core.state import AppState
 
 
 class SettingsPage(QWidget):
-    def __init__(self):
+    def __init__(self, state: AppState):
         super().__init__()
 
-        self._state: AppState | None = None
+        self._state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -93,11 +93,6 @@ class SettingsPage(QWidget):
 
     def bind_state(self, state: AppState) -> None:
         """将 UI 控件与全局状态 (AppState) 进行双向绑定"""
-        if self._state is state:
-            return
-
-        self._state = state
-
         # 普通属性，实时更新
         UIBinder.bind(self.sessdata_input, state, "sessdata", realtime=True)
         UIBinder.bind(self.bili_jct_input, state, "bili_jct", realtime=True)

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -91,19 +91,19 @@ class SettingsPage(QWidget):
 
         self.setLayout(main_layout)
 
-    def bind_state(self, state: AppState) -> None:
+    def bind_state(self) -> None:
         """将 UI 控件与全局状态 (AppState) 进行双向绑定"""
         # 普通属性，实时更新
-        UIBinder.bind(self.sessdata_input, state, "sessdata", realtime=True)
-        UIBinder.bind(self.bili_jct_input, state, "bili_jct", realtime=True)
+        UIBinder.bind(self.sessdata_input, self._state, "sessdata", realtime=True)
+        UIBinder.bind(self.bili_jct_input, self._state, "bili_jct", realtime=True)
 
         # 清空旧绑定，绑定 SenderConfig
-        UIBinder.bind(self.prevent_sleep_checkbox, state.sender_config, "prevent_sleep", clear_old=True)
-        UIBinder.bind(self.proxy_checkbox, state.sender_config, "use_system_proxy", clear_old=True)
+        UIBinder.bind(self.prevent_sleep_checkbox, self._state.sender_config, "prevent_sleep", clear_old=True)
+        UIBinder.bind(self.proxy_checkbox, self._state.sender_config, "use_system_proxy", clear_old=True)
 
         # 不清空，叠加绑定 MonitorConfig
-        UIBinder.bind(self.prevent_sleep_checkbox, state.monitor_config, "prevent_sleep", clear_old=False)
-        UIBinder.bind(self.proxy_checkbox, state.monitor_config, "use_system_proxy", clear_old=False)
+        UIBinder.bind(self.prevent_sleep_checkbox, self._state.monitor_config, "prevent_sleep", clear_old=False)
+        UIBinder.bind(self.proxy_checkbox, self._state.monitor_config, "use_system_proxy", clear_old=False)
 
     @Slot()
     def _open_qr_login(self):

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -107,9 +107,6 @@ class SettingsPage(QWidget):
 
     @Slot()
     def _open_qr_login(self):
-        if not self.state:
-            return
-
         proxy = self.state.sender_config.use_system_proxy
         dialog = QRLoginDialog(proxy, self)
 

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -15,7 +15,7 @@ class SettingsPage(QWidget):
     def __init__(self, state: AppState):
         super().__init__()
 
-        self._state = state
+        self.state = state
         self._create_ui()
 
     def _create_ui(self):
@@ -91,26 +91,26 @@ class SettingsPage(QWidget):
 
         self.setLayout(main_layout)
 
-    def bind_state(self) -> None:
+    def _init_bindings(self) -> None:
         """将 UI 控件与全局状态 (AppState) 进行双向绑定"""
         # 普通属性，实时更新
-        UIBinder.bind(self.sessdata_input, self._state, "sessdata", realtime=True)
-        UIBinder.bind(self.bili_jct_input, self._state, "bili_jct", realtime=True)
+        UIBinder.bind(self.sessdata_input, self.state, "sessdata", realtime=True)
+        UIBinder.bind(self.bili_jct_input, self.state, "bili_jct", realtime=True)
 
         # 清空旧绑定，绑定 SenderConfig
-        UIBinder.bind(self.prevent_sleep_checkbox, self._state.sender_config, "prevent_sleep", clear_old=True)
-        UIBinder.bind(self.proxy_checkbox, self._state.sender_config, "use_system_proxy", clear_old=True)
+        UIBinder.bind(self.prevent_sleep_checkbox, self.state.sender_config, "prevent_sleep", clear_old=True)
+        UIBinder.bind(self.proxy_checkbox, self.state.sender_config, "use_system_proxy", clear_old=True)
 
         # 不清空，叠加绑定 MonitorConfig
-        UIBinder.bind(self.prevent_sleep_checkbox, self._state.monitor_config, "prevent_sleep", clear_old=False)
-        UIBinder.bind(self.proxy_checkbox, self._state.monitor_config, "use_system_proxy", clear_old=False)
+        UIBinder.bind(self.prevent_sleep_checkbox, self.state.monitor_config, "prevent_sleep", clear_old=False)
+        UIBinder.bind(self.proxy_checkbox, self.state.monitor_config, "use_system_proxy", clear_old=False)
 
     @Slot()
     def _open_qr_login(self):
-        if not self._state:
+        if not self.state:
             return
 
-        proxy = self._state.sender_config.use_system_proxy
+        proxy = self.state.sender_config.use_system_proxy
         dialog = QRLoginDialog(proxy, self)
 
         # 阻塞等待弹窗返回。如果返回 Accepted，说明扫码成功


### PR DESCRIPTION
## Summary by Sourcery

将一个共享的 `AppState` 实例注入到所有主要的 UI 页面和控制器中，以消除可空状态和全局重新绑定逻辑。

增强内容：
- 重构 `SenderPage`、`EditorPage`、`MonitorPage`、`SettingsPage`、`HistoryPage` 以及相关 UI 组件，使其通过构造函数接收 `AppState`，而不是使用延迟绑定方法。
- 简化 `SenderController` 和各类 UI 组/标签页，通过存储一个非空的 `AppState` 引用，并将 `bind_state` 替换为一次性的 `_init_bindings` 钩子。
- 移除整个 UI 中多余的 `None` 检查以及状态重绑定/信号断开保护逻辑，改为依赖单一稳定的 `AppState` 实例连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject a shared AppState instance into all main UI pages and controllers to eliminate nullable state and global re-binding logic.

Enhancements:
- Refactor SenderPage, EditorPage, MonitorPage, SettingsPage, HistoryPage, and related UI components to receive AppState via constructors instead of late binding methods.
- Simplify SenderController and various UI groups/tabs by storing a non-null AppState reference and replacing bind_state with one-time _init_bindings hooks.
- Remove redundant None-checks and state rebinding/signal-disconnection safeguards across the UI in favor of a single stable AppState instance wiring.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将一个共享的 `AppState` 实例注入到所有主要的 UI 页面和控制器中，以消除可空状态和全局重新绑定逻辑。

增强内容：
- 重构 `SenderPage`、`EditorPage`、`MonitorPage`、`SettingsPage`、`HistoryPage` 以及相关 UI 组件，使其通过构造函数接收 `AppState`，而不是使用延迟绑定方法。
- 简化 `SenderController` 和各类 UI 组/标签页，通过存储一个非空的 `AppState` 引用，并将 `bind_state` 替换为一次性的 `_init_bindings` 钩子。
- 移除整个 UI 中多余的 `None` 检查以及状态重绑定/信号断开保护逻辑，改为依赖单一稳定的 `AppState` 实例连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject a shared AppState instance into all main UI pages and controllers to eliminate nullable state and global re-binding logic.

Enhancements:
- Refactor SenderPage, EditorPage, MonitorPage, SettingsPage, HistoryPage, and related UI components to receive AppState via constructors instead of late binding methods.
- Simplify SenderController and various UI groups/tabs by storing a non-null AppState reference and replacing bind_state with one-time _init_bindings hooks.
- Remove redundant None-checks and state rebinding/signal-disconnection safeguards across the UI in favor of a single stable AppState instance wiring.

</details>

</details>

增强内容：
- 在构造时将 `AppState` 注入到 `ValidationRulesGroup`、`EditorPage`、`SenderPage`、`MonitorPage`、`SettingsPage` 和 `HistoryPage` 中。
- 简化 `SenderController`：在其构造函数中要求传入 `AppState`，并移除单独的 `bind_state` 流程。
- 从 UI 的 `bind_state` 方法中移除现在不再需要的状态重新绑定逻辑和信号重新连接保护机制，改为依赖单一且一致的状态实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将一个共享的 `AppState` 实例注入到所有主要的 UI 页面和控制器中，以消除可空状态和全局重新绑定逻辑。

增强内容：
- 重构 `SenderPage`、`EditorPage`、`MonitorPage`、`SettingsPage`、`HistoryPage` 以及相关 UI 组件，使其通过构造函数接收 `AppState`，而不是使用延迟绑定方法。
- 简化 `SenderController` 和各类 UI 组/标签页，通过存储一个非空的 `AppState` 引用，并将 `bind_state` 替换为一次性的 `_init_bindings` 钩子。
- 移除整个 UI 中多余的 `None` 检查以及状态重绑定/信号断开保护逻辑，改为依赖单一稳定的 `AppState` 实例连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject a shared AppState instance into all main UI pages and controllers to eliminate nullable state and global re-binding logic.

Enhancements:
- Refactor SenderPage, EditorPage, MonitorPage, SettingsPage, HistoryPage, and related UI components to receive AppState via constructors instead of late binding methods.
- Simplify SenderController and various UI groups/tabs by storing a non-null AppState reference and replacing bind_state with one-time _init_bindings hooks.
- Remove redundant None-checks and state rebinding/signal-disconnection safeguards across the UI in favor of a single stable AppState instance wiring.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将一个共享的 `AppState` 实例注入到所有主要的 UI 页面和控制器中，以消除可空状态和全局重新绑定逻辑。

增强内容：
- 重构 `SenderPage`、`EditorPage`、`MonitorPage`、`SettingsPage`、`HistoryPage` 以及相关 UI 组件，使其通过构造函数接收 `AppState`，而不是使用延迟绑定方法。
- 简化 `SenderController` 和各类 UI 组/标签页，通过存储一个非空的 `AppState` 引用，并将 `bind_state` 替换为一次性的 `_init_bindings` 钩子。
- 移除整个 UI 中多余的 `None` 检查以及状态重绑定/信号断开保护逻辑，改为依赖单一稳定的 `AppState` 实例连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject a shared AppState instance into all main UI pages and controllers to eliminate nullable state and global re-binding logic.

Enhancements:
- Refactor SenderPage, EditorPage, MonitorPage, SettingsPage, HistoryPage, and related UI components to receive AppState via constructors instead of late binding methods.
- Simplify SenderController and various UI groups/tabs by storing a non-null AppState reference and replacing bind_state with one-time _init_bindings hooks.
- Remove redundant None-checks and state rebinding/signal-disconnection safeguards across the UI in favor of a single stable AppState instance wiring.

</details>

</details>

</details>