### PR TITLE
fix(types): DanmakuStatus 统一到 types/common.py，消除重复定义

### DIFF
--- a/src/danmaku_sender/core/database/history_manager.py
+++ b/src/danmaku_sender/core/database/history_manager.py
@@ -3,25 +3,18 @@ import time
 import threading
 from pathlib import Path
 from platformdirs import user_data_dir
-from enum import IntEnum
 
 from peewee import SqliteDatabase, fn, Case
 from playhouse.migrate import SqliteMigrator, migrate
 
-from ..entities.danmaku import Danmaku
 from .orm_models import db, SentDanmaku
-from ..types.common import VideoTarget
 
-from ...config.app_config import AppInfo
+from danmaku_sender.core.entities.danmaku import Danmaku
+from danmaku_sender.core.types.common import DanmakuStatus, VideoTarget
+from danmaku_sender.config.app_config import AppInfo
 
 
 logger = logging.getLogger("App.System.DB")
-
-
-class DanmakuStatus(IntEnum):
-    PENDING = 0   # 待验证
-    VERIFIED = 1  # 已存活
-    LOST = 2      # 已丢失
 
 
 class HistoryManager:

--- a/src/danmaku_sender/ui/history/components.py
+++ b/src/danmaku_sender/ui/history/components.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from PySide6.QtCore import Qt, QAbstractTableModel, QModelIndex
 from PySide6.QtGui import QColor, QBrush
 
-from ...core.database.history_manager import DanmakuStatus
+from ...core.types.common import DanmakuStatus
 from ...core.entities.video import VideoInfo
 
 

--- a/src/danmaku_sender/ui/history/dialogs.py
+++ b/src/danmaku_sender/ui/history/dialogs.py
@@ -4,7 +4,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QDialog, QFormLayout, QLabel, QFrame
 
 from ...core.entities.video import VideoInfo
-from ...core.database.history_manager import DanmakuStatus
+from ...core.types.common import DanmakuStatus
 
 
 class DanmakuDetailDialog(QDialog):

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -12,7 +12,7 @@ from .dialogs import DanmakuDetailDialog
 from ..controllers.video_controller import VideoController
 from ..controllers.history_controller import HistoryController
 
-from ...core.database.history_manager import DanmakuStatus
+from ...core.types.common import DanmakuStatus
 from ...core.entities.video import VideoInfo
 from ...core.state import AppState
 


### PR DESCRIPTION
## Summary by Sourcery

在共享的 types 模块中统一 DanmakuStatus 类型定义，并更新相关代码以使用集中管理的枚举。

Enhancements:
- 从历史记录管理器中移除本地定义的 `DanmakuStatus` 枚举，改为使用共享的 `types.common` 定义。
- 将与历史记录相关的模块切换为通过集中化的 `core/config` 模块导入 `DanmakuStatus`、`Danmaku`、`VideoTarget` 和 `AppInfo`，以保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify the DanmakuStatus type definition under the shared types module and update dependent code to use the centralized enum.

Enhancements:
- Remove the locally defined DanmakuStatus enum from the history manager in favor of the shared types.common definition.
- Switch history-related modules to import DanmakuStatus, Danmaku, VideoTarget, and AppInfo via the centralized core/config modules for consistency.

</details>