### PR TITLE
fix(ui): 移除构造函数注入后遗留的 state None 检查

### DIFF
--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -158,8 +158,7 @@ class HistoryPage(QWidget):
         将结果刷入表格，并触发缺失元数据的后台补全。
         """
         self._model.set_records(records)
-        if self.state:
-            self._fetch_missing_metadata(records)
+        self._fetch_missing_metadata(records)
 
     @Slot(object)
     def _on_history_query_failed(self, err: Exception):

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -392,8 +392,7 @@ class SenderPage(QWidget):
     def _set_ui_for_task_start(self):
         """任务开始时的 UI 状态设置"""
         # 通知全局状态
-        if self.state:
-            self.state.sender_is_active = True
+        self.state.sender_is_active = True
 
         # 按钮变红
         self.start_btn.setText("紧急停止")
@@ -409,8 +408,7 @@ class SenderPage(QWidget):
     def _reset_ui_after_task(self):
         """任务结束后的 UI 状态复位"""
         # 通知全局状态
-        if self.state:
-            self.state.sender_is_active = False
+        self.state.sender_is_active = False
 
         # 恢复按钮状态
         self.start_btn.setText("开始发送")
@@ -446,7 +444,7 @@ class SenderPage(QWidget):
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """鼠标拖拽文件进入页面区域"""
         # 如果当前正在发送弹幕则拒绝拖入
-        if self.state and self.state.sender_is_active:
+        if self.state.sender_is_active:
             event.ignore()
             return
 
@@ -462,7 +460,7 @@ class SenderPage(QWidget):
     def dropEvent(self, event: QDropEvent) -> None:
         """鼠标落下"""
         # 如果当前正在发送弹幕则拒绝拖入
-        if self.state and self.state.sender_is_active:
+        if self.state.sender_is_active:
             event.ignore()
             return
 


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

在强制使用非空状态注入后，移除 UI 组件中已过时的可选状态检查。

改进内容：
- 通过假定全局状态对象为非空，简化发送方页面的 UI 状态处理。
- 在历史记录查询成功后，始终触发缺失元数据的获取，而不再依赖可选状态进行判断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove obsolete optional state checks in UI components after enforcing non-null state injection.

Enhancements:
- Simplify sender page UI state handling by assuming a non-null global state object.
- Always trigger missing metadata fetching after history query success without guarding on optional state.

</details>