### PR TITLE
fix(exporter): create_xml_from_danmakus 写入失败时向调用方抛出异常

### DIFF
--- a/src/danmaku_sender/core/services/danmaku_exporter.py
+++ b/src/danmaku_sender/core/services/danmaku_exporter.py
@@ -52,6 +52,7 @@ def create_xml_from_danmakus(danmakus: list[UnsentDanmakusRecord], filepath: str
         logger.info(f"✅ 成功将 {len(danmakus)} 条弹幕及原因分类保存到 '{filepath}'。")
     except Exception as e:
         logger.error(f"❌ 保存未发送弹幕到XML文件失败: {e}", exc_info=True)
+        raise
 
 def export_danmakus_to_xml(danmakus: list[Danmaku], filepath: str) -> None:
     """


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过在 `create_xml_from_danmakus` 中重新抛出异常，确保 XML 导出失败不会被静默吞掉。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure XML export failures are not silently swallowed by re-raising exceptions from create_xml_from_danmakus.

</details>