### PR TITLE
refactor(concurrency): 重命名线程类并提取 submit 工厂方法

### DIFF
--- a/src/danmaku_sender/ui/controllers/auth_controller.py
+++ b/src/danmaku_sender/ui/controllers/auth_controller.py
@@ -1,9 +1,9 @@
 import logging
 import threading
 
-from PySide6.QtCore import QObject, Signal, QThreadPool, Slot
+from PySide6.QtCore import QObject, Signal, Slot
 
-from ..framework.concurrency import BaseWorker, GenericTask
+from ..framework.concurrency import WorkerThread, PoolTask
 
 from ...api.bili_api_client import BiliApiClient
 from ...core.state import ApiAuthConfig
@@ -61,11 +61,12 @@ class AuthController(QObject):
             self.userProfileReady.emit(UserProfile(False, "未登录"))
             return
 
-        task = GenericTask(_fetch_user_nav, auth_config)
-        task.signals.result.connect(self.userProfileReady.emit)
-
-        task.signals.error.connect(lambda _: self.userProfileReady.emit(UserProfile(False, "未登录")))
-        QThreadPool.globalInstance().start(task)
+        PoolTask.submit(
+            _fetch_user_nav,
+            self.userProfileReady.emit,
+            lambda _: self.userProfileReady.emit(UserProfile(False, "未登录")),
+            auth_config,
+        )
 
     def start_qr_login(self, use_system_proxy: bool):
         """启动扫码登录后台任务"""
@@ -108,7 +109,7 @@ class AuthController(QObject):
     # endregion
 
 
-class QRLoginWorker(BaseWorker):
+class QRLoginWorker(WorkerThread):
     """扫码登录后台轮询线程"""
     qrReady = Signal(str)           # 携带生成的二维码文本 (URL)
     statusUpdated = Signal(str)     # 携带当前扫码状态文案

--- a/src/danmaku_sender/ui/controllers/editor_controller.py
+++ b/src/danmaku_sender/ui/controllers/editor_controller.py
@@ -1,15 +1,16 @@
 import logging
 from typing import Callable
 
-from PySide6.QtCore import QObject, Signal, QThreadPool
+from PySide6.QtCore import QObject, Signal
 
-from ..framework.concurrency import GenericTask
+from ..framework.concurrency import PoolTask
 
 from ...core.engines.editor_session import EditorSession
 from ...core.state import AppState
 from ...core.entities.danmaku import Danmaku
 from ...core.types.editor_types import ViewItem, InsertPosition
 from ...core.services.danmaku_parser import DanmakuParser
+from ...core.services.danmaku_exporter import export_danmakus_to_xml
 
 
 class EditorController(QObject):
@@ -82,10 +83,27 @@ class EditorController(QObject):
             on_error: 失败回调，接收错误信息
         """
         parser = DanmakuParser()
-        task = GenericTask(parser.parse_xml_file, file_path)
-        task.signals.result.connect(lambda parsed: on_success(self._apply_parsed_to_workspace(parsed)))
-        task.signals.error.connect(lambda err: on_error(str(err)))
-        QThreadPool.globalInstance().start(task)
+        PoolTask.submit(
+            parser.parse_xml_file,
+            lambda parsed: on_success(self._apply_parsed_to_workspace(parsed)),
+            lambda err: on_error(str(err)),
+            file_path,
+        )
+
+    def export_to_xml(
+        self,
+        danmakus: list[Danmaku],
+        file_path: str,
+        on_success: Callable[[None], None],
+        on_error: Callable[[str], None],
+    ):
+        """异步导出弹幕列表到 XML 文件"""
+        PoolTask.submit(
+            export_danmakus_to_xml,
+            on_success,
+            lambda err: on_error(str(err)),
+            danmakus, file_path,
+        )
 
     def _apply_parsed_to_workspace(self, parsed_dms: list[Danmaku] | None) -> int:
         """

--- a/src/danmaku_sender/ui/controllers/history_controller.py
+++ b/src/danmaku_sender/ui/controllers/history_controller.py
@@ -1,8 +1,8 @@
 import logging
 
-from PySide6.QtCore import QObject, Signal, QThreadPool
+from PySide6.QtCore import QObject, Signal
 
-from ..framework.concurrency import GenericTask
+from ..framework.concurrency import PoolTask
 from ...core.database.history_manager import HistoryManager
 
 
@@ -25,11 +25,4 @@ class HistoryController(QObject):
 
     def query(self, keyword: str, status_filter: int):
         """发起异步数据库查询"""
-        task = GenericTask(_query, keyword, status_filter)
-
-        # 绑定回调
-        task.signals.result.connect(self.historyFetched.emit)
-        task.signals.error.connect(self.errorOccurred.emit)
-
-        # 提交到全局线程池
-        QThreadPool.globalInstance().start(task)
+        PoolTask.submit(_query, self.historyFetched.emit, self.errorOccurred.emit, keyword, status_filter)

--- a/src/danmaku_sender/ui/controllers/monitor_controller.py
+++ b/src/danmaku_sender/ui/controllers/monitor_controller.py
@@ -3,7 +3,7 @@ import threading
 
 from PySide6.QtCore import QObject, Signal, Slot
 
-from ..framework.concurrency import BaseWorker
+from ..framework.concurrency import WorkerThread
 
 from ...core.types.common import VideoTarget
 from ...core.state import ApiAuthConfig, MonitorConfig
@@ -76,7 +76,7 @@ class MonitorController(QObject):
     # endregion
 
 
-class MonitorTaskWorker(BaseWorker):
+class MonitorTaskWorker(WorkerThread):
     """监视任务后台线程"""
     statsUpdated = Signal(dict)
     statusUpdated = Signal(str)

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -1,9 +1,10 @@
 import logging
 import threading
+from typing import Callable
 
-from PySide6.QtCore import QObject, Signal, Slot, QThreadPool
+from PySide6.QtCore import QObject, Signal, Slot
 
-from danmaku_sender.ui.framework.concurrency import BaseWorker, GenericTask
+from danmaku_sender.ui.framework.concurrency import WorkerThread, PoolTask
 
 from danmaku_sender.core.database.history_manager import HistoryManager
 from danmaku_sender.core.engines.sender import DanmakuScheduler, DanmakuExecutor, SendingContext, SendJob
@@ -13,6 +14,7 @@ from danmaku_sender.core.types.result import DanmakuSendResult
 from danmaku_sender.core.types.common import VideoTarget
 from danmaku_sender.core.state import ApiAuthConfig, SenderConfig, AppState
 from danmaku_sender.core.services.danmaku_parser import DanmakuParser
+from danmaku_sender.core.services.danmaku_exporter import create_xml_from_danmakus, UnsentDanmakusRecord
 from danmaku_sender.api.bili_api_client import BiliApiClient
 from danmaku_sender.utils.system_utils import KeepSystemAwake
 
@@ -79,11 +81,27 @@ class SenderController(QObject):
         """异步解析 XML 弹幕文件"""
         self.state.video_state.loaded_danmakus = []
         parser = DanmakuParser()
-        task = GenericTask(parser.parse_xml_file, file_path)
-        task.signals.result.connect(lambda parsed: self._on_parse_success(parsed, file_path))
-        task.signals.error.connect(lambda err: self._on_parse_error(err, file_path))
-        QThreadPool.globalInstance().start(task)
+        PoolTask.submit(
+            parser.parse_xml_file,
+            lambda parsed: self._on_parse_success(parsed, file_path),
+            lambda err: self._on_parse_error(err, file_path),
+            file_path,
+        )
 
+    def export_unsent_xml(
+        self,
+        unsent_danmakus: list[UnsentDanmakusRecord],
+        file_path: str,
+        on_success: Callable[[None], None],
+        on_error: Callable[[str], None],
+    ):
+        """异步保存未发送弹幕到 XML 文件"""
+        PoolTask.submit(
+            create_xml_from_danmakus,
+            on_success,
+            lambda err: on_error(str(err)),
+            unsent_danmakus, file_path,
+        )
 
     # region Slots
 
@@ -112,7 +130,7 @@ class SenderController(QObject):
     # endregion
 
 
-class SendTaskWorker(BaseWorker):
+class SendTaskWorker(WorkerThread):
     """用于后台发送弹幕的线程"""
     progressUpdated = Signal(int, int, float)  # 已尝试, 总数, ETA
     taskFinished = Signal(object)              # SendingContext

--- a/src/danmaku_sender/ui/controllers/system_controller.py
+++ b/src/danmaku_sender/ui/controllers/system_controller.py
@@ -1,8 +1,8 @@
 import logging
 
-from PySide6.QtCore import QObject, Signal, Slot, QThreadPool
+from PySide6.QtCore import QObject, Signal, Slot
 
-from ..framework.concurrency import GenericTask
+from ..framework.concurrency import PoolTask
 from ...api.update_checker import UpdateChecker, UpdateInfo
 from ...config.app_config import AppInfo
 
@@ -38,12 +38,7 @@ class SystemController(QObject):
         self._update_check_in_flight = True
         self._in_flight_is_manual = is_manual
 
-        task = GenericTask(_check_update, use_proxy)
-
-        task.signals.result.connect(self._on_check_finished)
-        task.signals.error.connect(self._on_check_failed)
-
-        QThreadPool.globalInstance().start(task)
+        PoolTask.submit(_check_update, self._on_check_finished, self._on_check_failed, use_proxy)
 
     @Slot(object)
     def _on_check_finished(self, info: UpdateInfo):

--- a/src/danmaku_sender/ui/controllers/video_controller.py
+++ b/src/danmaku_sender/ui/controllers/video_controller.py
@@ -2,7 +2,7 @@ import logging
 
 from PySide6.QtCore import QObject, Signal, QThreadPool, Slot
 
-from ..framework.concurrency import GenericTask
+from ..framework.concurrency import PoolTask
 from ...core.entities.video import VideoInfo
 from ...core.state import ApiAuthConfig
 from ...core.services.video_fetcher import VideoFetcher
@@ -78,7 +78,7 @@ class VideoController(QObject):
         if not is_background:
             self.fetchStarted.emit()
 
-        task = GenericTask(_fetch_single_video_info, bvid, auth_config)
+        task = PoolTask(_fetch_single_video_info, bvid, auth_config)
 
         @Slot(object)
         def _on_fetch_succeeded(info: VideoInfo):
@@ -105,7 +105,7 @@ class VideoController(QObject):
         if not bvids:
             return
 
-        task = GenericTask(_fetch_multiple_video_infos, bvids, auth_config)
+        task = PoolTask(_fetch_multiple_video_infos, bvids, auth_config)
 
         @Slot(list)
         def _on_fetch_completed(results: list[tuple[str, VideoInfo | Exception]]):

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import Qt, QModelIndex, QPoint, Slot, QThreadPool
+from PySide6.QtCore import Qt, QModelIndex, QPoint, Slot
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
     QTableView, QHeaderView, QAbstractItemView, QMessageBox,
@@ -11,13 +11,11 @@ from PySide6.QtWidgets import (
 
 from .components import EditorTableModel, ValidationRulesGroup, PropertyInspectorGroup
 from .dialogs import EditDanmakuDialog, TimeOffsetDialog, ArrayGeneratorDialog
-from ..framework.concurrency import GenericTask
 from ..framework.style_loader import get_svg_icon
 from ..controllers.editor_controller import EditorController
 
 from ...core.types.editor_types import EditorField, InsertPosition
 from ...core.state import AppState
-from ...core.services.danmaku_exporter import export_danmakus_to_xml
 
 
 class EditorPage(QWidget):
@@ -331,10 +329,11 @@ class EditorPage(QWidget):
 
         if file_path:
             count = len(working_dms)
-            task = GenericTask(export_danmakus_to_xml, working_dms, file_path)
-            task.signals.result.connect(lambda _: self._on_export_success(count, file_path))
-            task.signals.error.connect(lambda err: self._on_export_error(str(err)))
-            QThreadPool.globalInstance().start(task)
+            self.controller.export_to_xml(
+                working_dms, file_path,
+                on_success=lambda _: self._on_export_success(count, file_path),
+                on_error=self._on_export_error,
+            )
 
     @Slot(int, str)
     def _on_export_success(self, count: int, file_path: str):

--- a/src/danmaku_sender/ui/framework/concurrency.py
+++ b/src/danmaku_sender/ui/framework/concurrency.py
@@ -4,13 +4,13 @@ import traceback
 from typing import Callable
 from abc import abstractmethod
 
-from PySide6.QtCore import QThread, QObject, Signal, QRunnable, Slot
+from PySide6.QtCore import QThread, QObject, Signal, QRunnable, Slot, QThreadPool
 
 
 logger = logging.getLogger("App.System.Concurrency")
 
 
-class BaseWorker(QThread):
+class WorkerThread(QThread):
     """
     所有长驻/重型 Worker 线程的抽象基类。
 
@@ -25,43 +25,42 @@ class BaseWorker(QThread):
         self.finished.connect(self._unregister)  # 线程彻底结束时，将自己从保活注册表中移除
 
     def start(self, *args, **kwargs):
-        """重写 start 方法，在启动时将自身加入保活注册表"""
-        with BaseWorker._registry_lock:
-            BaseWorker._keep_alive_registry.add(self)
+        """重写 start 方法: 在启动时将自身加入保活注册表"""
+        with WorkerThread._registry_lock:
+            WorkerThread._keep_alive_registry.add(self)
         super().start(*args, **kwargs)
 
     @Slot()
     def _unregister(self):
         """线程安全退出后释放 Python 引用"""
-        with BaseWorker._registry_lock:
-            BaseWorker._keep_alive_registry.discard(self)
+        with WorkerThread._registry_lock:
+            WorkerThread._keep_alive_registry.discard(self)
         self.logger.debug(f"{self.__class__.__name__} 已从全局存活注册表中移除。")
 
     @abstractmethod
     def run(self):
         """抽象方法: 子类必须重写此方法以实现具体的业务逻辑"""
-        raise NotImplementedError(f"继承 BaseWorker 的子类 {self.__class__.__name__} 必须实现 run() 方法")
+        raise NotImplementedError(f"继承 WorkerThread 的子类 {self.__class__.__name__} 必须实现 run() 方法")
 
     def report_error(self, title: str, exception: Exception):
         """统一的异常捕获与上报接口"""
         self.logger.error(f"{title}: {exception}", exc_info=True)
 
 
-class WorkerSignals(QObject):
+class PoolTaskSignals(QObject):
     """通用任务信号载体"""
     result = Signal(object)  # 携带任意类型的返回值
-    error = Signal(object)    # 携带异常对象
+    error = Signal(object)   # 携带异常对象
     finished = Signal()      # 无论成功失败，最后都会触发
 
 
-class GenericTask(QRunnable):
+class PoolTask(QRunnable):
     """
-    工业级通用线程池任务包装器
+    一次性线程池任务包装器
 
-    将任何普通的、阻塞的 Python 函数，
-    包装成一个可以在 QThreadPool 中安全运行的异步任务，并自动桥接信号。
+    将阻塞的 Python 函数包装成可在 QThreadPool 中安全运行的异步任务。
+    执行完毕后自动从注册表移除，适用于 API 调用、文件解析等短时操作。
     """
-    # 静态注册表: 存放所有正在运行的任务，以防止被 GC
     _keep_alive_registry = set()
     _registry_lock = threading.Lock()
 
@@ -70,15 +69,15 @@ class GenericTask(QRunnable):
         self.fn = fn
         self.args = args
         self.kwargs = kwargs
-        self.signals = WorkerSignals()
+        self.signals = PoolTaskSignals()
 
         self.setAutoDelete(False)  # 对象生命周期管理: C++ -> Python GC
 
-        with GenericTask._registry_lock:
-            GenericTask._keep_alive_registry.add(self)
+        with PoolTask._registry_lock:
+            PoolTask._keep_alive_registry.add(self)
 
     def run(self):
-        """线程池分配 OS 线程后自动调用的入口"""
+        """重写 QRunnable.run(): 线程池调度入口"""
         try:
             # 执行传入的业务函数
             result = self.fn(*self.args, **self.kwargs)
@@ -90,5 +89,14 @@ class GenericTask(QRunnable):
             self.signals.error.emit(e)
         finally:
             self.signals.finished.emit()
-            with GenericTask._registry_lock:
-                GenericTask._keep_alive_registry.discard(self)
+            with PoolTask._registry_lock:
+                PoolTask._keep_alive_registry.discard(self)
+
+    @classmethod
+    def submit(cls, fn: Callable, on_result: Callable, on_error: Callable, *args, **kwargs) -> 'PoolTask':
+        """将阻塞函数提交到全局线程池，连接结果和错误回调"""
+        task = cls(fn, *args, **kwargs)
+        task.signals.result.connect(on_result)
+        task.signals.error.connect(on_error)
+        QThreadPool.globalInstance().start(task)
+        return task

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -8,10 +8,9 @@ from PySide6.QtWidgets import (
     QFileDialog, QMessageBox
 )
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent
-from PySide6.QtCore import Qt, QDateTime, Slot, QThreadPool
+from PySide6.QtCore import Qt, QDateTime, Slot
 
 from .framework.binder import UIBinder
-from .framework.concurrency import GenericTask
 from .framework.style_loader import get_svg_icon
 from .controllers.video_controller import VideoController
 from .controllers.sender_controller import SenderController
@@ -19,7 +18,7 @@ from .controllers.sender_controller import SenderController
 from danmaku_sender.core.engines.sender.context import SendingContext
 from danmaku_sender.core.entities.video import VideoInfo
 from danmaku_sender.core.types.common import VideoTarget
-from danmaku_sender.core.services.danmaku_exporter import UnsentDanmakusRecord, create_xml_from_danmakus
+from danmaku_sender.core.services.danmaku_exporter import UnsentDanmakusRecord
 from danmaku_sender.core.state import AppState
 from danmaku_sender.utils.string_utils import parse_bilibili_link
 from danmaku_sender.utils.time_utils import format_duration
@@ -371,10 +370,11 @@ class SenderPage(QWidget):
             file_path, _ = QFileDialog.getSaveFileName(self, "保存XML", "unsent.xml", "XML Files (*.xml)")
             if file_path:
                 self.logger.info(f"📥 正在保存未发送弹幕至: {file_path}")
-                task = GenericTask(create_xml_from_danmakus, unsent_danmakus, file_path)
-                task.signals.result.connect(lambda _: self._on_export_success(file_path))
-                task.signals.error.connect(lambda err: self._on_export_error(str(err)))
-                QThreadPool.globalInstance().start(task)
+                self.sender_controller.export_unsent_xml(
+                    unsent_danmakus, file_path,
+                    on_success=lambda _: self._on_export_success(file_path),
+                    on_error=self._on_export_error,
+                )
 
     @Slot(str)
     def _on_export_success(self, file_path: str):


### PR DESCRIPTION
- BaseWorker → WorkerThread，GenericTask → PoolTask，WorkerSignals → PoolTaskSignals
- 提取 PoolTask.submit() 类方法替代独立的 run_task 函数
- 导出 XML 逻辑从 sender_page/editor_page 下沉到对应 controller
- UI 页面不再直接接触 PoolTask，职责边界更清晰

## Summary by Sourcery

通过重命名核心 worker/线程池抽象层、集中管理线程池任务提交逻辑，以及将 XML 导入/导出职责从 UI 页面迁移到其控制器中，对 UI 并发层进行重构。

改进内容：
- 将长生命周期的 worker 线程基类和线程池任务/信号辅助类型重命名为语义更清晰的 `WorkerThread`、`PoolTask` 和 `PoolTaskSignals`。
- 引入 `PoolTask.submit()` 类方法，用于统一向全局 `QThreadPool` 提交阻塞函数，并关联结果/错误回调。
- 更新各控制器，使用 `PoolTask`/`PoolTask.submit` 来处理 XML 解析、网络调用、数据库查询等异步工作，而不是在本地内联构造 `GenericTask` 并直接使用 `QThreadPool`。
- 将 XML 导入/导出以及未发送弹幕保存逻辑从 UI 页面移动到对应的控制器中，从而使视图不再直接与线程池任务交互。
- 统一所有 worker 子类（例如发送、二维码登录、监控 worker），使其继承重命名后的 `WorkerThread` 基类，以保持一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the UI concurrency layer by renaming core worker/thread-pool abstractions, centralizing thread-pool task submission, and moving XML import/export responsibilities from UI pages into their controllers.

Enhancements:
- Rename long‑lived worker thread base class and thread‑pool task/signal helper types to clearer WorkerThread, PoolTask, and PoolTaskSignals naming.
- Introduce a PoolTask.submit() class method to standardize submitting blocking functions to the global QThreadPool with result/error callbacks.
- Update controllers to use PoolTask/PoolTask.submit for asynchronous work such as XML parsing, network calls, and database queries instead of constructing GenericTask and QThreadPool usage inline.
- Move XML import/export and unsent‑danmaku save logic from UI pages into the corresponding controllers so views no longer interact with thread‑pool tasks directly.
- Align all worker subclasses (e.g., send, QR login, monitor workers) to inherit from the renamed WorkerThread base class for consistency.

</details>