### PR TITLE
refactor(types): UnsentDanmakusRecord 从 exporter 移至 types/common

### DIFF
--- a/src/danmaku_sender/core/engines/sender/context.py
+++ b/src/danmaku_sender/core/engines/sender/context.py
@@ -6,8 +6,7 @@ from enum import Enum, auto
 
 from ...entities.danmaku import Danmaku
 from ...types.result import DanmakuSendResult
-from ...types.common import VideoTarget
-from ...services.danmaku_exporter import UnsentDanmakusRecord
+from ...types.common import VideoTarget, UnsentDanmakusRecord
 from ...state import SenderConfig
 
 

--- a/src/danmaku_sender/core/services/danmaku_exporter.py
+++ b/src/danmaku_sender/core/services/danmaku_exporter.py
@@ -1,17 +1,12 @@
 import logging
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
-from typing import TypedDict
 
 from ..entities.danmaku import Danmaku
+from ..types.common import UnsentDanmakusRecord
 
 
 logger = logging.getLogger("App.System.Exporter")
-
-
-class UnsentDanmakusRecord(TypedDict):
-    dm: Danmaku
-    reason: str
 
 
 def create_xml_from_danmakus(danmakus: list[UnsentDanmakusRecord], filepath: str) -> None:

--- a/src/danmaku_sender/core/types/common.py
+++ b/src/danmaku_sender/core/types/common.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from enum import IntEnum
 from typing import TypedDict
 
+from ..entities.danmaku import Danmaku
+
 
 class DanmakuStatus(IntEnum):
     PENDING = 0   # 待验证
@@ -34,3 +36,9 @@ class AuthCookies(TypedDict):
     """身份凭证 Cookie 结构"""
     SESSDATA: str
     bili_jct: str
+
+
+class UnsentDanmakusRecord(TypedDict):
+    """未发送弹幕记录"""
+    dm: Danmaku
+    reason: str

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -11,10 +11,10 @@ from danmaku_sender.core.engines.sender import DanmakuScheduler, DanmakuExecutor
 from danmaku_sender.core.engines.sender.delay_manager import DelayManager
 from danmaku_sender.core.entities.danmaku import Danmaku
 from danmaku_sender.core.types.result import DanmakuSendResult
-from danmaku_sender.core.types.common import VideoTarget
+from danmaku_sender.core.types.common import VideoTarget, UnsentDanmakusRecord
 from danmaku_sender.core.state import ApiAuthConfig, SenderConfig, AppState
 from danmaku_sender.core.services.danmaku_parser import DanmakuParser
-from danmaku_sender.core.services.danmaku_exporter import create_xml_from_danmakus, UnsentDanmakusRecord
+from danmaku_sender.core.services.danmaku_exporter import create_xml_from_danmakus
 from danmaku_sender.api.bili_api_client import BiliApiClient
 from danmaku_sender.utils.system_utils import KeepSystemAwake
 

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -17,8 +17,7 @@ from .controllers.sender_controller import SenderController
 
 from danmaku_sender.core.engines.sender.context import SendingContext
 from danmaku_sender.core.entities.video import VideoInfo
-from danmaku_sender.core.types.common import VideoTarget
-from danmaku_sender.core.services.danmaku_exporter import UnsentDanmakusRecord
+from danmaku_sender.core.types.common import VideoTarget, UnsentDanmakusRecord
 from danmaku_sender.core.state import AppState
 from danmaku_sender.utils.string_utils import parse_bilibili_link
 from danmaku_sender.utils.time_utils import format_duration


### PR DESCRIPTION
消除 engine 对 service 的反向依赖，类型定义归入 types 层。

## Summary by Sourcery

增强功能：
- 在通用类型模块中引入共享的 `UnsentDanmakusRecord` `TypedDict`，并更新弹幕导出器以使用该类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Introduce a shared UnsentDanmakusRecord TypedDict in the common types module and update the danmaku exporter to consume it.

</details>