### PR TITLE
fix(editor): 移除弹幕预览框缩放逻辑，保持字号比例正确

### DIFF
--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -385,18 +385,6 @@ class DanmakuPreviewWidget(QWidget):
         text_width = fm.horizontalAdvance(self._text)
 
         rect = self.rect()
-        max_allowed_width = rect.width() - 20
-
-        scale_factor = 1.0
-        if text_width > max_allowed_width:
-            scale_factor = max_allowed_width / text_width
-
-            new_size = max(6, int(base_display_size * scale_factor))
-            font.setPointSize(new_size)
-
-            fm = QFontMetrics(font)
-            text_width = fm.horizontalAdvance(self._text)
-
         text_height = fm.ascent()
 
         x = (rect.width() - text_width) / 2
@@ -417,7 +405,7 @@ class DanmakuPreviewWidget(QWidget):
 
         # 绘制描边
         pen = QPen(QColor(0, 0, 0, 200))
-        stroke_width = max(1.0, 2.0 * scale_factor)
+        stroke_width = max(1.0, base_display_size / 12)
         pen.setWidthF(stroke_width)
         pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
 


### PR DESCRIPTION
缩放导致大字号长文本反而比小字号短文本更小。 改为不缩放，超出部分由 widget 自然裁剪。

## Summary by Sourcery

保持弹幕预览文本以配置的字体大小进行渲染，而不是自动缩放以适应预览框。

Bug 修复：
- 修复相对尺寸不正确的问题：由于预览缩放逻辑，较大、较长的文本可能会比较短的文本显示得更小。

增强：
- 调整文字描边宽度，使其与基础显示字体大小成比例，而不是依赖已移除的缩放因子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep danmaku preview text rendering at the configured font size without auto-scaling to fit the preview box.

Bug Fixes:
- Fix incorrect relative sizing where large, long texts could appear smaller than shorter texts due to preview scaling logic.

Enhancements:
- Adjust text stroke width to be proportional to the base display font size instead of the removed scaling factor.

</details>