### PR TITLE
fix(logging): GuiLoggingHandler 接收 SignalInstance 替代 callback，确保跨线程安全

### DIFF
--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -337,9 +337,9 @@ class MainWindow(QMainWindow):
                 break
 
         if gui_handler:
-            # 将 Handler 的回调指向 AppState 的信号
-            gui_handler.sender_callback = self.state.senderLogReceived.emit
-            gui_handler.monitor_callback = self.state.monitorLogReceived.emit
+            # 将 Handler 的信号指向 AppState 的信号
+            gui_handler.sender_signal = self.state.senderLogReceived
+            gui_handler.monitor_signal = self.state.monitorLogReceived
             self.logger.info("日志路由链路已接通。")
         else:
             self.logger.error("日志路由系统初始化失败：未找到 GuiLoggingHandler。")

--- a/src/danmaku_sender/utils/log_utils.py
+++ b/src/danmaku_sender/utils/log_utils.py
@@ -3,7 +3,8 @@ import logging
 import logging.handlers
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Callable
+
+from PySide6.QtCore import SignalInstance
 
 from ..config.app_config import AppInfo
 
@@ -16,30 +17,61 @@ class LogNamespace:
 
 
 class GuiLoggingHandler(logging.Handler):
-    """基于命名空间前缀路由日志到 UI 窗口"""
+    """基于命名空间前缀路由日志到 UI 窗口。
+
+    回调约束: sender / monitor 信号必须是 Qt SignalInstance，
+    以确保跨线程 emit 时自动排队到主线程，避免后台线程直接操作 UI。
+    """
     def __init__(self):
         super().__init__()
-        self.sender_callback: Callable[[str], None] | None = None
-        self.monitor_callback: Callable[[str], None] | None = None
+        self._sender_signal: SignalInstance | None = None
+        self._monitor_signal: SignalInstance | None = None
+
+    @property
+    def sender_signal(self) -> SignalInstance | None:
+        return self._sender_signal
+
+    @sender_signal.setter
+    def sender_signal(self, signal: SignalInstance | None):
+        if signal is not None and not isinstance(signal, SignalInstance):
+            raise TypeError(
+                f"sender_signal 必须是 SignalInstance，收到 {type(signal).__name__}。"
+                "直接 UI 操作在后台线程调用会导致崩溃。"
+            )
+        self._sender_signal = signal
+
+    @property
+    def monitor_signal(self) -> SignalInstance | None:
+        return self._monitor_signal
+
+    @monitor_signal.setter
+    def monitor_signal(self, signal: SignalInstance | None):
+        if signal is not None and not isinstance(signal, SignalInstance):
+            raise TypeError(
+                f"monitor_signal 必须是 SignalInstance，收到 {type(signal).__name__}。"
+                "直接 UI 操作在后台线程调用会导致崩溃。"
+            )
+        self._monitor_signal = signal
 
     def emit(self, record):
         """
         发出一条日志记录。
 
-        该方法会处理日志记录，并根据日志器名称前缀，将其路由至对应的回调函数。
+        该方法会处理日志记录，并根据日志器名称前缀，将其路由至对应的信号。
         它针对不同组件的日志做分流处理:
-        来自 "App.Sender" 的日志，分发至 sender_callback
-        来自 "App.Monitor" 的日志，分发至 monitor_callback
+        来自 "App.Sender" 的日志，发送至 sender_signal
+        来自 "App.Monitor" 的日志，发送至 monitor_signal
         来自 "App.System" 及其他来源的日志，将被忽略
 
         Args:
             record (logging.LogRecord)：待输出的日志记录对象。
         """
         try:
-            if record.name.startswith(LogNamespace.SENDER) and self.sender_callback:
-                self.sender_callback(self.format(record))
-            elif record.name.startswith(LogNamespace.MONITOR) and self.monitor_callback:
-                self.monitor_callback(self.format(record))
+            text = self.format(record)
+            if record.name.startswith(LogNamespace.SENDER) and self._sender_signal:
+                self._sender_signal.emit(text)
+            elif record.name.startswith(LogNamespace.MONITOR) and self._monitor_signal:
+                self._monitor_signal.emit(text)
             # App.System 或其他开头的日志直接忽略
         except Exception:
             self.handleError(record)


### PR DESCRIPTION
## Summary by Sourcery

重构 GUI 日志路由机制，使用 Qt 信号实例（Qt signal instances）在多线程环境下将日志安全地传递到 UI，而不是使用普通回调函数。

Enhancements:
- 将 `GuiLoggingHandler` 基于回调的路由替换为用于发送端和监控日志的 Qt `SignalInstance` 属性，以确保跨线程的 UI 更新是线程安全的。
- 添加类型校验和文档，强制 GUI 日志处理程序必须通过 `SignalInstance` 对象进行连接，而不是任意可调用对象。
- 更新主窗口的日志路由逻辑，通过新的信号属性将 `GuiLoggingHandler` 连接到 `AppState` 的信号。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor GUI logging routing to use Qt signal instances for thread-safe log delivery to the UI instead of plain callbacks.

Enhancements:
- Replace GuiLoggingHandler callback-based routing with Qt SignalInstance properties for sender and monitor logs to ensure cross-thread-safe UI updates.
- Add type validation and documentation to enforce that GUI logging handlers are wired with SignalInstance objects rather than arbitrary callables.
- Update main window log routing to connect GuiLoggingHandler to AppState signals via the new signal properties.

</details>