### PR TITLE
refactor(sender): SendingContext 承载手动停止状态，消除 UI 反向查询 Controller

### DIFF
--- a/src/danmaku_sender/core/engines/sender/context.py
+++ b/src/danmaku_sender/core/engines/sender/context.py
@@ -62,6 +62,7 @@ class SendingContext:
     start_time: float = field(default_factory=time.time)
     auto_stop_reason: str = ""          # 如果触发了自动停止，记录具体原因
     fatal_error_occurred: bool = False  # 是否因致命错误而崩塌
+    is_manually_stopped: bool = False   # 是否被用户手动停止
 
     # 失败弹幕回收站，供后续导出 XML 使用
     unsent_records: list[UnsentDanmakusRecord] = field(default_factory=list)

--- a/src/danmaku_sender/ui/controllers/sender_controller.py
+++ b/src/danmaku_sender/ui/controllers/sender_controller.py
@@ -163,6 +163,7 @@ class SendTaskWorker(WorkerThread):
             self.report_error("任务发生严重错误", e)
         finally:
             if ctx:
+                ctx.is_manually_stopped = self.stop_event.is_set()
                 self._log_summary(ctx)
             self.taskFinished.emit(ctx)
 
@@ -209,7 +210,7 @@ class SendTaskWorker(WorkerThread):
         self.logger.info("--- 发送任务结束 ---")
         if ctx.auto_stop_reason:
             self.logger.info(f"原因：{ctx.auto_stop_reason}")
-        elif self.stop_event.is_set():
+        elif ctx.is_manually_stopped:
             self.logger.info("原因：任务被用户手动停止。")
         elif ctx.fatal_error_occurred:
             self.logger.critical("原因：任务因致命错误中断。请检查配置或网络！")

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -322,8 +322,7 @@ class SenderPage(QWidget):
         # 恢复 UI
         self._reset_ui_after_task()
 
-        is_stopped = self.sender_controller.is_stopped_manually()
-        if is_stopped:
+        if ctx and ctx.is_manually_stopped:
             self.status_label.setText("发送器：任务中止")
             self.progress_bar.setFormat("%p% (已停止)")
         else:
@@ -331,7 +330,7 @@ class SenderPage(QWidget):
             self.progress_bar.setFormat("%p% (已完成)")
 
         if ctx:
-            self._send_desktop_notification(ctx, is_stopped)
+            self._send_desktop_notification(ctx, ctx.is_manually_stopped)
 
             # 如果有未发出的弹幕，引导保存
             if ctx.unsent_records:


### PR DESCRIPTION
## Summary by Sourcery

增强：
- 扩展 `SendingContext` 以携带一个手动停止标记，并使用该标记来确定完成状态和日志消息，而不是从 UI 检查控制器状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extend SendingContext to carry a manual stop flag and use it to determine completion status and logging messages instead of checking controller state from the UI.

</details>