### PR TITLE
refactor(ui): _init_bindings 重命名为公共接口 + closeEvent 凭证逻辑提取至 AccountController

### DIFF
--- a/src/danmaku_sender/ui/controllers/account_controller.py
+++ b/src/danmaku_sender/ui/controllers/account_controller.py
@@ -5,8 +5,10 @@ from PySide6.QtCore import QObject, Signal
 
 from danmaku_sender.api.bili_api_client import BiliApiClient
 from danmaku_sender.core.models.account import AccountCredential
-from danmaku_sender.core.state import ApiAuthConfig
+from danmaku_sender.core.models.user import UserProfile
+from danmaku_sender.core.state import ApiAuthConfig, AppState
 from danmaku_sender.ui.framework.concurrency import PoolTask
+from danmaku_sender.utils.account_manager import save_accounts
 
 
 logger = logging.getLogger("App.System.Account")
@@ -41,6 +43,28 @@ class AccountController(QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+
+    @staticmethod
+    def save_credentials(state: AppState, profile: UserProfile | None):
+        """同步 sessdata/bili_jct 到已保存账号列表并写盘"""
+        if not state.sessdata or not state.bili_jct:
+            return
+
+        for acc in state.saved_accounts:
+            if acc.sessdata == state.sessdata:
+                acc.bili_jct = state.bili_jct
+                if profile and profile.is_login:
+                    acc.name = profile.username
+                break
+        else:
+            acc = AccountCredential(sessdata=state.sessdata, bili_jct=state.bili_jct)
+            if profile and profile.is_login:
+                acc.name = profile.username
+            state.saved_accounts.append(acc)
+
+        save_accounts(state.saved_accounts)
+        if state.saved_accounts:
+            logger.info(f"已保存 {len(state.saved_accounts)} 个账号。")
 
     def check_account(self, account: AccountCredential, config: ApiAuthConfig):
         """异步检测账号是否有效"""

--- a/src/danmaku_sender/ui/editor/components.py
+++ b/src/danmaku_sender/ui/editor/components.py
@@ -124,7 +124,7 @@ class ValidationRulesGroup(QGroupBox):
 
         layout.addLayout(keyword_layout)
 
-    def _init_bindings(self):
+    def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
         config = self.state.validation_config
 

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -176,9 +176,9 @@ class EditorPage(QWidget):
 
         self._update_ui_state()
 
-    def _init_bindings(self):
+    def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.rules_group._init_bindings()
+        self.rules_group.init_bindings()
         self._update_ui_state()
 
     # endregion

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -92,7 +92,7 @@ class HistoryPage(QWidget):
         self.history_controller.historyFetched.connect(self._on_history_query_succeeded)
         self.history_controller.errorOccurred.connect(self._on_history_query_failed)
 
-    def _init_bindings(self):
+    def init_bindings(self):
         self._refresh_table()
 
     @Slot()

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices
 from PySide6.QtCore import Qt, QUrl, QTimer, QSize, QEvent, Slot
 
 from .controllers.auth_controller import AuthController, UserProfile
+from .controllers.account_controller import AccountController
 from .controllers.system_controller import SystemController
 from .framework.image_processor import QtImageProcessor
 from .framework.style_loader import load_stylesheet, get_svg_icon, get_app_icon
@@ -27,8 +28,7 @@ from ..core.state import AppState
 from ..core.models.common import MonitorStats
 from ..core.models.user import UserProfile
 from ..utils.log_utils import GuiLoggingHandler
-from ..utils.account_manager import load_accounts, save_accounts
-from ..core.models.account import AccountCredential
+from ..utils.account_manager import load_accounts
 from ..utils.config_manager import load_app_config, save_app_config
 
 
@@ -91,29 +91,7 @@ class MainWindow(QMainWindow):
     def closeEvent(self, event: QCloseEvent):
         """窗口关闭事件: 保存配置与凭证"""
         try:
-            # 同步当前凭证到已保存列表
-            if self.state.sessdata and self.state.bili_jct:
-                found = False
-                for acc in self.state.saved_accounts:
-                    if acc.sessdata == self.state.sessdata:
-                        acc.bili_jct = self.state.bili_jct
-                        if self._current_profile and self._current_profile.is_login:
-                            acc.name = self._current_profile.username
-                        found = True
-                        break
-
-                if not found:
-                    acc = AccountCredential(
-                        sessdata=self.state.sessdata,
-                        bili_jct=self.state.bili_jct,
-                    )
-                    if self._current_profile and self._current_profile.is_login:
-                        acc.name = self._current_profile.username
-                    self.state.saved_accounts.append(acc)
-
-                save_accounts(self.state.saved_accounts)
-                if self.state.saved_accounts:
-                    self.logger.info(f"已保存 {len(self.state.saved_accounts)} 个账号。")
+            AccountController.save_credentials(self.state, self._current_profile)
         except Exception as e:
             self.logger.error(f"保存凭证失败: {e}")
 
@@ -307,11 +285,11 @@ class MainWindow(QMainWindow):
     def _bind_state_to_pages(self):
         """绑定全局状态并配置日志路由"""
         # 页面数据绑定
-        self.page_settings._init_bindings()
-        self.page_sender._init_bindings()
-        self.page_editor._init_bindings()
-        self.page_monitor._init_bindings()
-        self.page_history._init_bindings()
+        self.page_settings.init_bindings()
+        self.page_sender.init_bindings()
+        self.page_editor.init_bindings()
+        self.page_monitor.init_bindings()
+        self.page_history.init_bindings()
 
         # 日志分流：信号 -> Tab 接口
         if self._log_signals_connected:

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -180,7 +180,7 @@ class MonitorPage(QWidget):
         self.monitor_controller.statusUpdated.connect(self.status_label.setText)
         self.monitor_controller.taskFinished.connect(self._on_finished)
 
-    def _init_bindings(self):
+    def init_bindings(self):
         # 初始化与绑定
         UIBinder.bind(self.interval_spin, self.state.monitor_config, "refresh_interval")
 

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -110,10 +110,10 @@ class SenderPage(QWidget):
         self.sender_controller.xmlParsed.connect(self._on_xml_parsed)
         self.sender_controller.xmlParseFailed.connect(self._on_xml_parse_failed)
 
-    def _init_bindings(self):
+    def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.basic_group._init_bindings()
-        self.strategy_tabs._init_bindings()
+        self.basic_group.init_bindings()
+        self.strategy_tabs.init_bindings()
 
     def append_log(self, message: str):
         """外部调用的日志接口"""
@@ -519,7 +519,7 @@ class BasicParamsGroup(QGroupBox):
         layout.addRow(QLabel("弹幕文件:"), file_layout)
         layout.addRow(QLabel(""), self.skip_sent_cb)
 
-    def _init_bindings(self):
+    def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
         UIBinder.bind(self.bv_input, self.state.video_state, "bvid", realtime=True)
         UIBinder.bind(self.skip_sent_cb, self.state.sender_config, "skip_sent")
@@ -634,7 +634,7 @@ class StrategySettingsTabs(QTabWidget):
 
         self.addTab(stop_tab, "自动终止")
 
-    def _init_bindings(self):
+    def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
         config = self.state.sender_config
 

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -52,7 +52,7 @@ class SettingsPage(QWidget):
 
         self.setLayout(main_layout)
 
-    def _init_bindings(self) -> None:
+    def init_bindings(self) -> None:
         """将 UI 控件与全局状态 (AppState) 进行双向绑定"""
         UIBinder.bind(self.prevent_sleep_checkbox, self.state.sender_config, "prevent_sleep", clear_old=True)
         UIBinder.bind(self.proxy_checkbox, self.state.sender_config, "use_system_proxy", clear_old=True)


### PR DESCRIPTION
## Summary by Sourcery

将账户凭据持久化提取到共享的控制器工具中，并在各页面之间统一 UI 绑定方法的命名。

Enhancements:
- 将账户凭据保存逻辑从主窗口关闭处理程序中移至 `AccountController.save_credentials`，以便复用并使职责分离更加清晰。
- 将所有页面的绑定方法从 `_init_bindings` 重命名并更新为公共的 `init_bindings`，以统一 UI 绑定接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract account credential persistence into a shared controller utility and standardize UI binding method names across pages.

Enhancements:
- Move account credential save logic from the main window close handler into AccountController.save_credentials for reuse and clearer separation of concerns.
- Rename and update all page binding methods from _init_bindings to the public init_bindings to unify the UI binding interface.

</details>