### PR TITLE
refactor(sender): 提取 SendPipeline，Controller 不再直接依赖 repo 层

### DIFF
--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -5,19 +5,15 @@ from typing import Callable
 from PySide6.QtCore import QObject, Signal, Slot
 
 from .concurrency import WorkerThread, PoolTask
-
 from .system_utils import KeepSystemAwake
 
-from danmaku_sender.repo.history_manager import HistoryManager
-from danmaku_sender.service.sender import DanmakuScheduler, DanmakuExecutor, SendingContext, SendJob, DelayManager
+from danmaku_sender.service.sender import SendPipeline, SendingContext, SendJob
+from danmaku_sender.service.danmaku_parser import DanmakuParser
+from danmaku_sender.service.danmaku_exporter import create_xml_from_danmakus
 from danmaku_sender.types.models.danmaku import Danmaku
-from danmaku_sender.types.models.result import DanmakuSendResult
 from danmaku_sender.types.models.common import VideoTarget, UnsentDanmakusRecord
 from danmaku_sender.config import ApiAuthConfig, SenderConfig
 from danmaku_sender.runtime.app_state import AppState
-from danmaku_sender.service.danmaku_parser import DanmakuParser
-from danmaku_sender.service.danmaku_exporter import create_xml_from_danmakus
-from danmaku_sender.repo.bili_api_client import BiliApiClient
 
 
 logger = logging.getLogger("App.Controller.Sender")
@@ -132,7 +128,7 @@ class SenderController(QObject):
 
 
 class SendTaskWorker(WorkerThread):
-    """用于后台发送弹幕的线程"""
+    """用于后台发送弹幕的线程（薄壳：仅负责线程生命周期与信号桥接）"""
     progressUpdated = Signal(int, int, float)  # 已尝试, 总数, ETA
     taskFinished = Signal(object)              # SendingContext
 
@@ -146,76 +142,25 @@ class SendTaskWorker(WorkerThread):
         parent=None
     ):
         super().__init__(parent)
-        self.logger = logging.getLogger("App.Controller.Sender.Worker")
         self.target = target
         self.danmakus = danmakus
         self.auth_config = auth_config
         self.strategy_config = strategy_config
         self.stop_event = stop_event
-        self.sender_instance = None
-        self.history_manager = HistoryManager()
-        self.scheduler = None
 
     def run(self):
         ctx = None
         try:
-            ctx = self._execute_pipeline()
+            with KeepSystemAwake(self.strategy_config.prevent_sleep):
+                pipeline = SendPipeline(self.auth_config, self.strategy_config)
+                job = SendJob(
+                    target=self.target,
+                    danmakus=self.danmakus,
+                    config=self.strategy_config,
+                    stop_event=self.stop_event,
+                )
+                ctx = pipeline.execute(job, progress_emitter=self.progressUpdated.emit)
         except Exception as e:
             self.report_error("任务发生严重错误", e)
         finally:
-            if ctx:
-                ctx.is_manually_stopped = self.stop_event.is_set()
-                self._log_summary(ctx)
             self.taskFinished.emit(ctx)
-
-    def _execute_pipeline(self):
-        with (
-            KeepSystemAwake(self.strategy_config.prevent_sleep),
-            BiliApiClient.from_config(self.auth_config) as client
-        ):
-            executor = DanmakuExecutor(client)
-            self.scheduler = DanmakuScheduler(executor, self.history_manager)
-
-            job = SendJob(
-                target=self.target,
-                danmakus=self.danmakus,
-                config=self.strategy_config,
-                stop_event=self.stop_event,
-                progress_callback=self._handle_job_progress,
-                result_callback=self._handle_job_result
-            )
-            return self.scheduler.run_pipeline(job)
-
-    def _handle_job_progress(self, attempted: int, total: int):
-        avg_normal = (self.strategy_config.min_delay + self.strategy_config.max_delay) / 2
-        avg_rest = (self.strategy_config.rest_min + self.strategy_config.rest_max) / 2
-
-        eta_sec = DelayManager.calc_eta(
-            attempted=attempted,
-            total=total,
-            burst_size=self.strategy_config.burst_size,
-            avg_normal=avg_normal,
-            avg_rest=avg_rest
-        )
-
-        self.progressUpdated.emit(attempted, total, eta_sec)
-
-    def _handle_job_result(self, dm: Danmaku, result: DanmakuSendResult):
-        if result.is_success and result.dmid:
-            if not dm.dmid:
-                dm.dmid = result.dmid
-            self.history_manager.record_danmaku(self.target, dm, result.is_visible)
-
-    def _log_summary(self, ctx: SendingContext):
-        """日志输出"""
-        self.logger.info("--- 发送任务结束 ---")
-        if ctx.auto_stop_reason:
-            self.logger.info(f"原因：{ctx.auto_stop_reason}")
-        elif ctx.is_manually_stopped:
-            self.logger.info("原因：任务被用户手动停止。")
-        elif ctx.fatal_error_occurred:
-            self.logger.critical("原因：任务因致命错误中断。请检查配置或网络！")
-        else:
-            self.logger.info("原因：所有弹幕已处理完毕。")
-
-        self.logger.info(f"总计: {ctx.total} | 成功: {ctx.success_count} | 跳过: {ctx.skipped_count} | 失败: {ctx.attempted_count - ctx.success_count}")

--- a/src/danmaku_sender/service/sender/__init__.py
+++ b/src/danmaku_sender/service/sender/__init__.py
@@ -2,15 +2,24 @@
 发送引擎模块 (Sender Engine)
 
 本模块遵循单一职责原则 (SRP) 和参数对象模式 (Parameter Object Pattern) 设计。
+- SendPipeline: 发送管线编排器，封装完整生命周期（组装、执行、记录、摘要）。
 - DanmakuScheduler: 负责控制流、限流、断点续传与中断响应。
 - DanmakuExecutor: 负责纯粹的网络 I/O 与发包处理。
 - SendJob & SendingContext: 负责携带与记录整个发送生命周期的数据状态。
 """
 
+from .pipeline import SendPipeline
 from .scheduler import DanmakuScheduler
 from .executor import DanmakuExecutor
 from .context import SendingContext, SendJob
 from .delay_manager import DelayManager
 
 
-__all__ = ["DanmakuScheduler", "DanmakuExecutor", "SendingContext", "SendJob", "DelayManager"]
+__all__ = [
+    "SendPipeline",
+    "DanmakuScheduler",
+    "DanmakuExecutor",
+    "SendingContext",
+    "SendJob",
+    "DelayManager",
+]

--- a/src/danmaku_sender/service/sender/context.py
+++ b/src/danmaku_sender/service/sender/context.py
@@ -2,7 +2,6 @@ import time
 from threading import Event
 from typing import Callable
 from dataclasses import dataclass, field
-from enum import Enum, auto
 
 from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.result import DanmakuSendResult
@@ -13,15 +12,6 @@ from danmaku_sender.config import SenderConfig
 # 弹幕指纹类型别名：(内容, 进度, 模式, 字号, 颜色)
 # 用于在断点续传时，精准判断两条弹幕是否在物理表现上完全一致
 DanmakuFingerprint = tuple[str, int, int, int, int]
-
-
-class SendFlowAction(Enum):
-    """
-    发送流程控制动作枚举
-    指示调度器在收到一次发送结果后，下一步该作何反应
-    """
-    CONTINUE = auto()     # 结果正常，继续发送下一条
-    STOP_FATAL = auto()   # 遇到严重权限/网络错误，立即停止
 
 
 @dataclass

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -93,8 +93,8 @@ class SendPipeline:
 
     def _record_result(self, target: VideoTarget, dm: Danmaku, result: DanmakuSendResult):
         """将成功发送的弹幕记录到历史数据库"""
-        if result.is_success:
-            if result.dmid and not dm.dmid:
+        if result.is_success and result.dmid:
+            if not dm.dmid:
                 dm.dmid = result.dmid
             self.history_manager.record_danmaku(target, dm, result.is_visible)
 

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -6,6 +6,7 @@ Controller 层的 Worker 只需调用 pipeline.execute()，无需接触 Executor
 """
 
 import logging
+from dataclasses import replace
 from typing import Callable
 
 from .scheduler import DanmakuScheduler
@@ -69,17 +70,14 @@ class SendPipeline:
                     outer_result_callback(dm, result)
 
             def on_progress(attempted: int, total: int):
-                eta_sec = self._calc_eta(attempted, total)
+                eta_sec = self._calc_eta(attempted, total, job.config)
                 if progress_emitter:
                     progress_emitter(attempted, total, eta_sec)
                 if outer_progress_callback:
                     outer_progress_callback(attempted, total)
 
-            wrapped_job = SendJob(
-                target=job.target,
-                danmakus=job.danmakus,
-                config=job.config,
-                stop_event=job.stop_event,
+            wrapped_job = replace(
+                job,
                 progress_callback=on_progress,
                 result_callback=on_result,
             )
@@ -98,9 +96,9 @@ class SendPipeline:
                 dm.dmid = result.dmid
             self.history_manager.record_danmaku(target, dm, result.is_visible)
 
-    def _calc_eta(self, attempted: int, total: int) -> float:
-        """基于当前策略配置计算 ETA（秒）"""
-        cfg = self.strategy_config
+    def _calc_eta(self, attempted: int, total: int, config: SenderConfig) -> float:
+        """基于任务配置计算 ETA（秒）"""
+        cfg = config
         avg_normal = (cfg.min_delay + cfg.max_delay) / 2
         avg_rest = (cfg.rest_min + cfg.rest_max) / 2
         return DelayManager.calc_eta(

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -59,28 +59,32 @@ class SendPipeline:
             executor = DanmakuExecutor(client)
             scheduler = DanmakuScheduler(executor, self.history_manager)
 
-            # 组装回调链：结果记录 → 外部回调
-            original_result_callback = job.result_callback
+            # 包装回调链，不修改原始 job 对象
+            outer_result_callback = job.result_callback
+            outer_progress_callback = job.progress_callback
 
             def on_result(dm: Danmaku, result: DanmakuSendResult):
                 self._record_result(job.target, dm, result)
-                if original_result_callback:
-                    original_result_callback(dm, result)
-
-            # 组装回调链：ETA 计算 → 进度发射 → 外部回调
-            original_progress_callback = job.progress_callback
+                if outer_result_callback:
+                    outer_result_callback(dm, result)
 
             def on_progress(attempted: int, total: int):
                 eta_sec = self._calc_eta(attempted, total)
                 if progress_emitter:
                     progress_emitter(attempted, total, eta_sec)
-                if original_progress_callback:
-                    original_progress_callback(attempted, total)
+                if outer_progress_callback:
+                    outer_progress_callback(attempted, total)
 
-            job.result_callback = on_result
-            job.progress_callback = on_progress
+            wrapped_job = SendJob(
+                target=job.target,
+                danmakus=job.danmakus,
+                config=job.config,
+                stop_event=job.stop_event,
+                progress_callback=on_progress,
+                result_callback=on_result,
+            )
 
-            ctx = scheduler.run_pipeline(job)
+            ctx = scheduler.run_pipeline(wrapped_job)
 
         # 补充生命周期状态
         ctx.is_manually_stopped = job.stop_event.is_set()
@@ -90,6 +94,8 @@ class SendPipeline:
     def _record_result(self, target: VideoTarget, dm: Danmaku, result: DanmakuSendResult):
         """将成功发送的弹幕记录到历史数据库"""
         if result.is_success:
+            if result.dmid and not dm.dmid:
+                dm.dmid = result.dmid
             self.history_manager.record_danmaku(target, dm, result.is_visible)
 
     def _calc_eta(self, attempted: int, total: int) -> float:

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -1,0 +1,125 @@
+"""
+发送管线编排器 (Send Pipeline)
+
+封装单次发送任务的完整生命周期：资源组装、调度执行、结果记录、摘要日志。
+Controller 层的 Worker 只需调用 pipeline.execute()，无需接触 Executor/Scheduler 细节。
+"""
+
+import logging
+from typing import Callable
+
+from .scheduler import DanmakuScheduler
+from .executor import DanmakuExecutor
+from .context import SendingContext, SendJob
+from .delay_manager import DelayManager
+
+from danmaku_sender.repo.bili_api_client import BiliApiClient
+from danmaku_sender.repo.history_manager import HistoryManager
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.result import DanmakuSendResult
+from danmaku_sender.types.models.common import VideoTarget
+from danmaku_sender.config import ApiAuthConfig, SenderConfig
+
+
+logger = logging.getLogger("App.Sender.Pipeline")
+
+
+class SendPipeline:
+    """
+    发送管线编排器
+
+    职责：
+    - 组装 BiliApiClient / Executor / Scheduler
+    - 将成功结果记录到 HistoryManager
+    - 计算 ETA 并回调进度
+    - 输出任务摘要日志
+    """
+
+    def __init__(self, auth_config: ApiAuthConfig, strategy_config: SenderConfig):
+        self.auth_config = auth_config
+        self.strategy_config = strategy_config
+        self.history_manager = HistoryManager()
+
+    def execute(
+        self,
+        job: SendJob,
+        progress_emitter: Callable[[int, int, float], None] | None = None,
+    ) -> SendingContext:
+        """
+        执行完整的发送管线。
+
+        Args:
+            job: 发送任务工单（含目标、弹幕、配置、回调）
+            progress_emitter: 进度信号发射器 (attempted, total, eta_sec)，由 Worker 桥接
+
+        Returns:
+            SendingContext: 包含统计数据的发送上下文
+        """
+        with BiliApiClient.from_config(self.auth_config) as client:
+            executor = DanmakuExecutor(client)
+            scheduler = DanmakuScheduler(executor, self.history_manager)
+
+            # 组装回调链：结果记录 → 外部回调
+            original_result_callback = job.result_callback
+
+            def on_result(dm: Danmaku, result: DanmakuSendResult):
+                self._record_result(job.target, dm, result)
+                if original_result_callback:
+                    original_result_callback(dm, result)
+
+            # 组装回调链：ETA 计算 → 进度发射 → 外部回调
+            original_progress_callback = job.progress_callback
+
+            def on_progress(attempted: int, total: int):
+                eta_sec = self._calc_eta(attempted, total)
+                if progress_emitter:
+                    progress_emitter(attempted, total, eta_sec)
+                if original_progress_callback:
+                    original_progress_callback(attempted, total)
+
+            job.result_callback = on_result
+            job.progress_callback = on_progress
+
+            ctx = scheduler.run_pipeline(job)
+
+        # 补充生命周期状态
+        ctx.is_manually_stopped = job.stop_event.is_set()
+        self._log_summary(ctx)
+        return ctx
+
+    def _record_result(self, target: VideoTarget, dm: Danmaku, result: DanmakuSendResult):
+        """将成功发送的弹幕记录到历史数据库"""
+        if result.is_success:
+            self.history_manager.record_danmaku(target, dm, result.is_visible)
+
+    def _calc_eta(self, attempted: int, total: int) -> float:
+        """基于当前策略配置计算 ETA（秒）"""
+        cfg = self.strategy_config
+        avg_normal = (cfg.min_delay + cfg.max_delay) / 2
+        avg_rest = (cfg.rest_min + cfg.rest_max) / 2
+        return DelayManager.calc_eta(
+            attempted=attempted,
+            total=total,
+            burst_size=cfg.burst_size,
+            avg_normal=avg_normal,
+            avg_rest=avg_rest,
+        )
+
+    @staticmethod
+    def _log_summary(ctx: SendingContext):
+        """输出任务结束摘要"""
+        logger.info("--- 发送任务结束 ---")
+        if ctx.auto_stop_reason:
+            logger.info(f"原因：{ctx.auto_stop_reason}")
+        elif ctx.is_manually_stopped:
+            logger.info("原因：任务被用户手动停止。")
+        elif ctx.fatal_error_occurred:
+            logger.critical("原因：任务因致命错误中断。请检查配置或网络！")
+        else:
+            logger.info("原因：所有弹幕已处理完毕。")
+
+        failed = ctx.attempted_count - ctx.success_count
+        logger.info(
+            f"总计: {ctx.total} | 成功: {ctx.success_count} | "
+            f"跳过: {ctx.skipped_count} | 失败: {failed}"
+        )

--- a/src/danmaku_sender/service/sender/scheduler.py
+++ b/src/danmaku_sender/service/sender/scheduler.py
@@ -20,7 +20,6 @@ class DanmakuScheduler:
         self.logger = logging.getLogger("App.Sender.Scheduler")
         self.executor = executor
         self.history_manager = history_manager
-        self.unsent_danmakus = []
 
     @staticmethod
     def _get_fingerprint(dm: Danmaku) -> DanmakuFingerprint:
@@ -79,7 +78,6 @@ class DanmakuScheduler:
 
         # 初始化统计容器
         ctx = SendingContext(total=len(job.danmakus), config=job.config, target=job.target)
-        self.unsent_danmakus = []
 
         if not job.danmakus:
             return ctx
@@ -143,5 +141,4 @@ class DanmakuScheduler:
                     ctx.add_unsent(job.danmakus[i+1:], "任务手动停止")
                 break
 
-        self.unsent_danmakus = ctx.unsent_records
         return ctx


### PR DESCRIPTION
- 新增 service/sender/pipeline.py：封装发送管线完整生命周期（资源组装、结果记录、ETA 计算、摘要日志）
- SendTaskWorker 瘦身：从 90 行减至 38 行，仅负责线程生命周期与信号桥接
- 清理 SendFlowAction 死代码、scheduler.unsent_danmakus 冗余存储

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

增强内容：
- 将 `SendTaskWorker` 重构为一个轻量封装层，该封装层将发送编排委托给 `SendPipeline`，自身只负责管理线程生命周期和信号桥接。
- 将客户端、调度器、历史记录、ETA（预计到达时间）计算以及摘要日志能力封装到新的 `SendPipeline` 服务 API 中。
- 移除未使用的 `SendFlowAction` 枚举以及调度器中多余的 `unsent_danmakus` 存储，以简化发送上下文管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

增强内容：
- 将 `SendTaskWorker` 重构为一个轻量封装层，该封装层将发送编排委托给 `SendPipeline`，自身只负责管理线程生命周期和信号桥接。
- 将客户端、调度器、历史记录、ETA（预计到达时间）计算以及摘要日志能力封装到新的 `SendPipeline` 服务 API 中。
- 移除未使用的 `SendFlowAction` 枚举以及调度器中多余的 `unsent_danmakus` 存储，以简化发送上下文管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

</details>

</details>

改进内容：
- 引入 SendPipeline 编排器，将调度器、执行器、历史记录、ETA 计算和摘要日志统一封装在一个简单的 `execute` API 背后。
- 重构 `SendTaskWorker`，将发送编排委托给 `SendPipeline`，将其职责限制为线程生命周期管理和信号桥接。
- 移除未使用的 `SendFlowAction` 枚举以及调度器中冗余的 `unsent_danmakus` 存储，以简化发送上下文管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

增强内容：
- 将 `SendTaskWorker` 重构为一个轻量封装层，该封装层将发送编排委托给 `SendPipeline`，自身只负责管理线程生命周期和信号桥接。
- 将客户端、调度器、历史记录、ETA（预计到达时间）计算以及摘要日志能力封装到新的 `SendPipeline` 服务 API 中。
- 移除未使用的 `SendFlowAction` 枚举以及调度器中多余的 `unsent_danmakus` 存储，以简化发送上下文管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

增强内容：
- 将 `SendTaskWorker` 重构为一个轻量封装层，该封装层将发送编排委托给 `SendPipeline`，自身只负责管理线程生命周期和信号桥接。
- 将客户端、调度器、历史记录、ETA（预计到达时间）计算以及摘要日志能力封装到新的 `SendPipeline` 服务 API 中。
- 移除未使用的 `SendFlowAction` 枚举以及调度器中多余的 `unsent_danmakus` 存储，以简化发送上下文管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入专门的 SendPipeline 服务来编排弹幕发送流程，将控制器中的线程工作器与发送器内部实现解耦，并简化生命周期管理。

改进内容：
- 重构 SendTaskWorker，使其成为一个轻量封装层，将发送流程的编排委托给 SendPipeline，自身专注于线程生命周期管理和信号桥接。
- 新增 SendPipeline 作为发送服务，用于组装 client/executor/scheduler，计算预计到达时间（ETA），记录历史，并为每个发送任务记录总结日志。
- 通过移除未使用的 SendFlowAction 枚举和多余的 unsent_danmakus 状态，简化发送上下文和调度器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated SendPipeline service to orchestrate danmaku sending, decoupling the controller thread worker from sender internals and simplifying lifecycle handling.

Enhancements:
- Refactor SendTaskWorker into a thin wrapper that delegates sending orchestration to SendPipeline and focuses on thread lifecycle and signal bridging.
- Add SendPipeline as a sender service that assembles client/executor/scheduler, computes ETA, records history, and logs summary for a send job.
- Simplify sender context and scheduler by removing the unused SendFlowAction enum and redundant unsent_danmakus state.

</details>

</details>

</details>

</details>