### PR TITLE
refactor(repo): HistoryManager 去单例化，改为构造函数依赖注入

### DIFF
--- a/src/danmaku_sender/config/app_meta.py
+++ b/src/danmaku_sender/config/app_meta.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 from platformdirs import user_data_dir
 
-from .._version import __version__
+from danmaku_sender._version import __version__
+
+
+# 应用数据目录（import 时计算，运行时不变）
+_DATA_DIR = Path(user_data_dir("BiliDanmakuSender", "Miku_oso"))
+_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 
 class AppInfo:
@@ -12,17 +17,14 @@ class AppInfo:
     AUTHOR = "Miku_oso"
     VERSION = __version__
     LOG_FILE_NAME = "latest.log"
-    LOG_DIR_NAME = "logs"
 
-
-def get_data_dir() -> Path:
-    """获取应用数据目录（跨平台）"""
-    return Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR))
-
-
-def get_history_db_path() -> Path:
-    """获取历史记录数据库路径"""
-    return get_data_dir() / "history.db"
+    class Paths:
+        """所有应用路径的集中定义"""
+        DATA = _DATA_DIR
+        HISTORY_DB = _DATA_DIR / "history.db"
+        CONFIG = _DATA_DIR / "config.json"
+        LOGS = _DATA_DIR / "logs"
+        ACCOUNTS = _DATA_DIR / "accounts.json"
 
 
 class UI:

--- a/src/danmaku_sender/controller/history_controller.py
+++ b/src/danmaku_sender/controller/history_controller.py
@@ -3,16 +3,11 @@ import logging
 from PySide6.QtCore import QObject, Signal
 
 from .concurrency import PoolTask
+
 from danmaku_sender.repo.history_manager import HistoryManager
 
 
 logger = logging.getLogger("App.Controller.History")
-
-
-def _query(keyword: str, status_filter: int) -> list:
-    """纯业务逻辑：从单例的 HistoryManager 获取数据"""
-    hm = HistoryManager()
-    return hm.query_history(keyword, status_filter)
 
 
 class HistoryController(QObject):
@@ -20,9 +15,15 @@ class HistoryController(QObject):
     historyFetched = Signal(list)
     errorOccurred = Signal(object)
 
-    def __init__(self, parent=None):
+    def __init__(self, history_manager: HistoryManager, parent=None):
         super().__init__(parent)
+        self.history_manager = history_manager
 
     def query(self, keyword: str, status_filter: int):
         """发起异步数据库查询"""
-        PoolTask.submit(_query, self.historyFetched.emit, self.errorOccurred.emit, keyword, status_filter)
+        PoolTask.submit(
+            self.history_manager.query_history,
+            self.historyFetched.emit,
+            self.errorOccurred.emit,
+            keyword, status_filter,
+        )

--- a/src/danmaku_sender/controller/monitor_controller.py
+++ b/src/danmaku_sender/controller/monitor_controller.py
@@ -6,6 +6,7 @@ from PySide6.QtCore import QObject, Signal, Slot
 from .concurrency import WorkerThread
 from .system_utils import KeepSystemAwake
 
+from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.types.models.common import VideoTarget
 from danmaku_sender.config import ApiAuthConfig, MonitorConfig
 from danmaku_sender.service.bili_monitor import BiliDanmakuMonitor
@@ -20,8 +21,9 @@ class MonitorController(QObject):
     statusUpdated = Signal(str)
     taskFinished = Signal()
 
-    def __init__(self, parent=None):
+    def __init__(self, history_manager: HistoryManager, parent=None):
         super().__init__(parent)
+        self.history_manager = history_manager
         self._worker: MonitorTaskWorker | None = None
         self._stop_event = threading.Event()
 
@@ -37,7 +39,8 @@ class MonitorController(QObject):
             target=target,
             auth_config=auth_config,
             monitor_config=monitor_config,
-            stop_event=self._stop_event
+            stop_event=self._stop_event,
+            history_manager=self.history_manager,
         )
 
         self._worker.statsUpdated.connect(self.statsUpdated.emit)
@@ -87,6 +90,7 @@ class MonitorTaskWorker(WorkerThread):
         auth_config: ApiAuthConfig,
         monitor_config: MonitorConfig,
         stop_event: threading.Event,
+        history_manager: HistoryManager,
         parent=None
     ):
         super().__init__(parent)
@@ -95,6 +99,7 @@ class MonitorTaskWorker(WorkerThread):
         self.auth_config = auth_config
         self.monitor_config = monitor_config
         self.stop_event = stop_event
+        self.history_manager = history_manager
 
     def run(self):
         try:
@@ -107,7 +112,7 @@ class MonitorTaskWorker(WorkerThread):
     def _run_monitor_loop(self):
         with (
             KeepSystemAwake(self.monitor_config.prevent_sleep),
-            BiliDanmakuMonitor.create(self.target, self.auth_config) as monitor
+            BiliDanmakuMonitor.create(self.target, self.auth_config, self.history_manager) as monitor
         ):
             self.logger.info(f"🛡️ 监视启动: {self.target.display_string} | CID: {self.target.cid}")
 

--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -12,6 +12,7 @@ from danmaku_sender.service.danmaku_parser import DanmakuParser
 from danmaku_sender.service.danmaku_exporter import create_xml_from_danmakus
 from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import VideoTarget, UnsentDanmakusRecord
+from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.config import ApiAuthConfig, SenderConfig
 from danmaku_sender.runtime.app_state import AppState
 
@@ -26,9 +27,10 @@ class SenderController(QObject):
     xmlParsed = Signal(str, int)          # file_path, danmaku_count
     xmlParseFailed = Signal(str, object)  # file_path, raw_exception
 
-    def __init__(self, state: AppState, parent=None):
+    def __init__(self, state: AppState, history_manager: HistoryManager, parent=None):
         super().__init__(parent)
         self.state = state
+        self.history_manager = history_manager
         self._worker: SendTaskWorker | None = None
         self._stop_event = threading.Event()
 
@@ -51,7 +53,8 @@ class SenderController(QObject):
             danmakus=danmakus,
             auth_config=auth_config,
             strategy_config=strategy_config,
-            stop_event=self._stop_event
+            stop_event=self._stop_event,
+            history_manager=self.history_manager,
         )
 
         self._worker.progressUpdated.connect(self.progressUpdated.emit)
@@ -139,6 +142,7 @@ class SendTaskWorker(WorkerThread):
         auth_config: ApiAuthConfig,
         strategy_config: SenderConfig,
         stop_event: threading.Event,
+        history_manager: HistoryManager,
         parent=None
     ):
         super().__init__(parent)
@@ -147,12 +151,13 @@ class SendTaskWorker(WorkerThread):
         self.auth_config = auth_config
         self.strategy_config = strategy_config
         self.stop_event = stop_event
+        self.history_manager = history_manager
 
     def run(self):
         ctx = None
         try:
             with KeepSystemAwake(self.strategy_config.prevent_sleep):
-                pipeline = SendPipeline(self.auth_config, self.strategy_config)
+                pipeline = SendPipeline(self.auth_config, self.strategy_config, self.history_manager)
                 job = SendJob(
                     target=self.target,
                     danmakus=self.danmakus,

--- a/src/danmaku_sender/main.py
+++ b/src/danmaku_sender/main.py
@@ -1,13 +1,11 @@
 import sys
 import ctypes
-from pathlib import Path
-from platformdirs import user_data_dir
 
 from PySide6.QtWidgets import QApplication
 
-from .config.app_meta import AppInfo
-from .ui.framework.style_loader import get_app_icon
-from .runtime.log_utils import init_app_logging
+from danmaku_sender.config.app_meta import AppInfo
+from danmaku_sender.runtime.log_utils import init_app_logging
+from danmaku_sender.ui.framework.style_loader import get_app_icon
 
 
 def main(argv=None):
@@ -27,7 +25,7 @@ def main(argv=None):
         argv = sys.argv
 
     # 初始化日志
-    log_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR)) / AppInfo.LOG_DIR_NAME
+    log_dir = AppInfo.Paths.LOGS
     init_app_logging(log_dir)
 
     from .runtime import Runtime

--- a/src/danmaku_sender/repo/history_manager.py
+++ b/src/danmaku_sender/repo/history_manager.py
@@ -31,7 +31,6 @@ class HistoryManager:
 
     def __init__(self, db_path: Path):
         self.db_path = db_path
-        db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init_db()
         logger.debug("HistoryManager 初始化完成")
 

--- a/src/danmaku_sender/repo/history_manager.py
+++ b/src/danmaku_sender/repo/history_manager.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import threading
 from pathlib import Path
 
 from peewee import SqliteDatabase, fn, Case
@@ -21,7 +20,6 @@ class HistoryManager:
     负责实现"发送 -> 存证 -> 核销"的数据层逻辑。
 
     线程安全契约:
-    - 单例在主线程初始化，之后可安全地在任意线程调用其公共方法。
     - Peewee 的 SqliteDatabase 内部使用 threading.local() 为每个线程维护
       独立的 SQLite 连接，不存在跨线程共享连接的问题。
     - WAL 模式允许并发读 + 单写，配合 Peewee 的线程本地连接机制，
@@ -29,55 +27,13 @@ class HistoryManager:
       高写入并发或长事务仍可能触发 ``database is locked`` 错误。
     - 每个写操作均为单条 SQL（Peewee 默认 autocommit），在上述前提下是原子操作，
       但不意味着该历史层在任意写入压力下都具备高可扩展性。
-
-    注意：当前的单例实现仅针对单进程多线程环境。
-    如果在多进程环境中使用，SQLite 的文件锁机制会处理并发，但单例逻辑会失效。
-
-    初始化契约:
-    - 应用启动时必须先调用 ``HistoryManager.initialize(db_path)`` 完成初始化。
-    - 之后任意位置可通过 ``HistoryManager()`` 获取单例实例。
-    - 未初始化时调用 ``HistoryManager()`` 会抛出 ``RuntimeError``。
     """
-    _instance: "HistoryManager | None" = None
-    _lock = threading.Lock()
-    _initialized = False
-    db_path: Path  # 由 initialize() 设置的实例属性
 
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            raise RuntimeError(
-                "HistoryManager 尚未初始化，请先调用 HistoryManager.initialize(db_path)"
-            )
-        return cls._instance
-
-    @classmethod
-    def initialize(cls, db_path: Path) -> "HistoryManager":
-        """
-        初始化单例（应用启动时调用一次）。
-
-        Args:
-            db_path: SQLite 数据库文件路径
-
-        Returns:
-            初始化后的 HistoryManager 单例
-
-        Raises:
-            RuntimeError: 重复初始化时抛出
-        """
-        with cls._lock:
-            if cls._initialized:
-                raise RuntimeError("HistoryManager 已经初始化，不可重复调用 initialize()")
-
-            instance = super().__new__(cls)
-            cls._instance = instance
-
-            db_path.parent.mkdir(parents=True, exist_ok=True)
-            instance.db_path = db_path
-            instance._init_db()
-
-            cls._initialized = True
-            logger.debug("HistoryManager 单例初始化完成")
-            return instance
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+        logger.debug("HistoryManager 初始化完成")
 
     def _init_db(self):
         """初始化数据库，自动迁移"""

--- a/src/danmaku_sender/runtime/account_manager.py
+++ b/src/danmaku_sender/runtime/account_manager.py
@@ -4,16 +4,16 @@ import logging
 import keyring
 from pathlib import Path
 from cryptography.fernet import Fernet, InvalidToken
-from platformdirs import user_data_dir
 
-from ..config.app_meta import AppInfo
-from ..types.models.account import AccountCredential
 from .app_state import AppState
+
+from danmaku_sender.config.app_meta import AppInfo
+from danmaku_sender.types.models.account import AccountCredential
 
 
 KEYRING_SERVICE_NAME = f"{AppInfo.NAME_EN}-CredentialsKey"
 KEYRING_USERNAME = "default_user"
-ACCOUNTS_FILE_NAME = "accounts.json"
+ACCOUNTS_PATH = AppInfo.Paths.ACCOUNTS
 
 logger = logging.getLogger("App.System.Auth")
 
@@ -48,33 +48,26 @@ class AccountManager:
             logger.warning(f"密钥环写入失败: {e}，密钥仅在本次会话有效，跳过凭据持久化。")
             return new_key, False
 
-    def get_accounts_filepath(self) -> Path:
-        """获取账号存储文件的完整路径"""
-        data_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR, ensure_exists=True))
-        return data_dir / ACCOUNTS_FILE_NAME
-
     def load_accounts(self) -> list[AccountCredential]:
         """
         从加密的 accounts.json 加载账号列表。
         如果文件不存在或解密失败，返回空列表。
         """
-        accounts_file = self.get_accounts_filepath()
-
-        if not accounts_file.exists():
+        if not ACCOUNTS_PATH.exists():
             return []
 
         try:
             key, _ = self._get_encryption_key()
             fernet = Fernet(key)
 
-            encrypted_data = accounts_file.read_bytes()
+            encrypted_data = ACCOUNTS_PATH.read_bytes()
             decrypted_data = fernet.decrypt(encrypted_data)
 
             raw_list = json.loads(decrypted_data.decode('utf-8'))
 
             if not isinstance(raw_list, list):
                 logger.warning("accounts.json 格式异常：顶层不是列表，已备份。")
-                self._backup_corrupt_file(accounts_file)
+                self._backup_corrupt_file(ACCOUNTS_PATH)
                 return []
 
             accounts = []
@@ -93,7 +86,7 @@ class AccountManager:
 
         except json.JSONDecodeError as e:
             logger.warning(f"账号文件 JSON 解析失败（文件损坏）: {e}")
-            self._backup_corrupt_file(accounts_file)
+            self._backup_corrupt_file(ACCOUNTS_PATH)
             return []
 
         except Exception as unexpected_e:
@@ -102,13 +95,11 @@ class AccountManager:
 
     def save_accounts(self, accounts: list[AccountCredential]) -> None:
         """将账号列表加密后写入 accounts.json。"""
-        accounts_file = self.get_accounts_filepath()
-
         if not accounts:
             logger.info("账号列表为空，删除账号文件。")
-            if accounts_file.exists():
+            if ACCOUNTS_PATH.exists():
                 try:
-                    os.remove(accounts_file)
+                    os.remove(ACCOUNTS_PATH)
                 except OSError as e:
                     logger.error(f"删除账号文件失败: {e}", exc_info=True)
             return
@@ -125,8 +116,8 @@ class AccountManager:
             json_bytes = json.dumps(raw_list, ensure_ascii=False).encode('utf-8')
             encrypted_bytes = f.encrypt(json_bytes)
 
-            accounts_file.write_bytes(encrypted_bytes)
-            logger.info(f"已保存 {len(accounts)} 个账号到 {accounts_file}")
+            ACCOUNTS_PATH.write_bytes(encrypted_bytes)
+            logger.info(f"已保存 {len(accounts)} 个账号到 {ACCOUNTS_PATH}")
         except Exception as e:
             logger.error(f"保存账号数据失败: {e}", exc_info=True)
 

--- a/src/danmaku_sender/runtime/config_manager.py
+++ b/src/danmaku_sender/runtime/config_manager.py
@@ -1,25 +1,21 @@
 import json
 import logging
-from pathlib import Path
-from platformdirs import user_data_dir
 
 from pydantic import ValidationError, BaseModel
 
-from ..config.app_meta import AppInfo
-from ..config import SenderConfig, MonitorConfig, ValidationConfig
 from .app_state import AppState
+
+from danmaku_sender.config.app_meta import AppInfo
+from danmaku_sender.config import SenderConfig, MonitorConfig, ValidationConfig
 
 
 logger = logging.getLogger("App.System.Config")
 
+CONFIG_PATH = AppInfo.Paths.CONFIG
+
 
 class ConfigManager:
     """配置管理器"""
-
-    def get_config_path(self) -> Path:
-        config_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR))
-        config_dir.mkdir(parents=True, exist_ok=True)
-        return config_dir / "config.json"
 
     def save(self, state: AppState) -> None:
         """保存非敏感配置到 config.json"""
@@ -30,25 +26,23 @@ class ConfigManager:
         }
 
         try:
-            path = self.get_config_path()
-            with open(path, 'w', encoding='utf-8') as f:
+            with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
                 json.dump(config_data, f, indent=2)
-            logger.info(f"配置已保存: {path}")
+            logger.info(f"配置已保存: {CONFIG_PATH}")
         except Exception as e:
             logger.error(f"保存配置失败: {e}")
 
     def load(self, state: AppState) -> None:
         """从 config.json 加载配置到 state"""
-        path = self.get_config_path()
-        if not path.exists():
+        if not CONFIG_PATH.exists():
             logger.info("未找到配置文件，使用默认设置。")
             return
 
         try:
-            with open(path, 'r', encoding='utf-8') as f:
+            with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
                 data = json.load(f)
         except json.JSONDecodeError as e:
-            logger.error(f"配置文件 JSON 格式损坏，将使用默认设置[{path}]: {e}")
+            logger.error(f"配置文件 JSON 格式损坏，将使用默认设置[{CONFIG_PATH}]: {e}")
             return
         except Exception as e:
             logger.error(f"读取配置文件失败: {e}")
@@ -67,4 +61,4 @@ class ConfigManager:
         state.monitor_config = _load_section("monitor", MonitorConfig, state.monitor_config)
         state.validation_config = _load_section("validation", ValidationConfig, state.validation_config)
 
-        logger.info(f"配置文件加载与校验流程结束[{path}]。")
+        logger.info(f"配置文件加载与校验流程结束[{CONFIG_PATH}]。")

--- a/src/danmaku_sender/runtime/runtime.py
+++ b/src/danmaku_sender/runtime/runtime.py
@@ -37,7 +37,7 @@ class Runtime:
         self._bootstrapped = True
 
         # === 数据库 ===
-        self.history_manager = HistoryManager.initialize(get_history_db_path())
+        self.history_manager = HistoryManager(get_history_db_path())
 
         self.resources.theme.init_theme()
 

--- a/src/danmaku_sender/runtime/runtime.py
+++ b/src/danmaku_sender/runtime/runtime.py
@@ -4,8 +4,10 @@ from .resources import AppResources
 from .app_state import AppState
 from .config_manager import ConfigManager
 from .account_manager import AccountManager
-from ..repo.history_manager import HistoryManager
-from ..config.app_meta import get_history_db_path
+
+from danmaku_sender.config.app_meta import AppInfo
+from danmaku_sender.repo.history_manager import HistoryManager
+
 
 logger = logging.getLogger("App.Runtime")
 
@@ -37,7 +39,7 @@ class Runtime:
         self._bootstrapped = True
 
         # === 数据库 ===
-        self.history_manager = HistoryManager(get_history_db_path())
+        self.history_manager = HistoryManager(AppInfo.Paths.HISTORY_DB)
 
         self.resources.theme.init_theme()
 

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -19,20 +19,20 @@ class BiliDanmakuMonitor:
     通过 context manager 工厂创建，自动管理 BiliApiClient 生命周期。
     """
 
-    def __init__(self, api_client: BiliApiClient, target: VideoTarget):
+    def __init__(self, api_client: BiliApiClient, target: VideoTarget, history_manager: HistoryManager):
         self.api_client = api_client
         self.target = target
 
         self.danmaku_parser = DanmakuParser()
-        self.history_manager = HistoryManager()
+        self.history_manager = history_manager
         self.logger = logging.getLogger("App.Monitor.Engine")
 
     @staticmethod
     @contextmanager
-    def create(target: VideoTarget, auth_config: ApiAuthConfig):
+    def create(target: VideoTarget, auth_config: ApiAuthConfig, history_manager: HistoryManager):
         """Context manager 工厂：自动管理 client 生命周期"""
         with BiliApiClient.from_config(auth_config) as client:
-            yield BiliDanmakuMonitor(api_client=client, target=target)
+            yield BiliDanmakuMonitor(api_client=client, target=target, history_manager=history_manager)
 
     def _fetch_online_danmakus(self) -> list[Danmaku]:
         """获取在线弹幕列表"""

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -36,10 +36,15 @@ class SendPipeline:
     - 输出任务摘要日志
     """
 
-    def __init__(self, auth_config: ApiAuthConfig, strategy_config: SenderConfig):
+    def __init__(
+        self,
+        auth_config: ApiAuthConfig,
+        strategy_config: SenderConfig,
+        history_manager: HistoryManager,
+    ):
         self.auth_config = auth_config
         self.strategy_config = strategy_config
-        self.history_manager = HistoryManager()
+        self.history_manager = history_manager
 
     def execute(
         self,

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -13,6 +13,7 @@ from .dialogs import DanmakuDetailDialog
 from danmaku_sender.types.models.common import DanmakuStatus
 from danmaku_sender.types.models.video import VideoInfo
 from danmaku_sender.runtime.app_state import AppState
+from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.controller.video_controller import VideoController
 from danmaku_sender.controller.history_controller import HistoryController
 
@@ -21,13 +22,13 @@ logger = logging.getLogger("App.System.UI.History")
 
 
 class HistoryPage(QWidget):
-    def __init__(self, state: AppState):
+    def __init__(self, state: AppState, history_manager: HistoryManager):
         super().__init__()
         self.state = state
         self._fetched_bvids = set()
 
         self.video_controller = VideoController(self)
-        self.history_controller = HistoryController(self)
+        self.history_controller = HistoryController(history_manager, self)
 
         self._create_ui()
         self._connect_signals()

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -1,6 +1,4 @@
 import logging
-from pathlib import Path
-from platformdirs import user_data_dir
 
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QMessageBox, QHBoxLayout, QVBoxLayout, QFrame, QApplication,
@@ -9,9 +7,6 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices
 from PySide6.QtCore import Qt, QUrl, QTimer, QSize, QEvent, Slot
 
-from danmaku_sender.controller.auth_controller import AuthController, UserProfile
-from danmaku_sender.controller.account_controller import AccountController
-from danmaku_sender.controller.system_controller import SystemController
 from .framework.image_processor import QtImageProcessor
 from .framework.style_loader import load_stylesheet, get_svg_icon, get_app_icon
 from .sender_page import SenderPage
@@ -21,13 +16,16 @@ from .editor import EditorPage
 from .dialogs import AboutDialog, HelpDialog, UpdateDialog
 from .account_manager import AccountDialog
 from .history import HistoryPage
-from danmaku_sender.runtime.theme_manager import ThemeManager
 
-from ..config.app_meta import AppInfo, UI
-from ..types.models.common import MonitorStats
-from ..types.models.user import UserProfile
-from ..runtime import Runtime
-from ..runtime.log_utils import GuiLoggingHandler
+from danmaku_sender.config.app_meta import AppInfo, UI
+from danmaku_sender.types.models.common import MonitorStats
+from danmaku_sender.types.models.user import UserProfile
+from danmaku_sender.runtime import Runtime
+from danmaku_sender.runtime.log_utils import GuiLoggingHandler
+from danmaku_sender.runtime.theme_manager import ThemeManager
+from danmaku_sender.controller.auth_controller import AuthController, UserProfile
+from danmaku_sender.controller.account_controller import AccountController
+from danmaku_sender.controller.system_controller import SystemController
 
 
 class MainWindow(QMainWindow):
@@ -383,7 +381,7 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def _open_log_folder(self):
-        log_dir = Path(user_data_dir(AppInfo.NAME_EN, AppInfo.AUTHOR)) / AppInfo.LOG_DIR_NAME
+        log_dir = AppInfo.Paths.LOGS
         if not log_dir.exists():
             try:
                 log_dir.mkdir(parents=True, exist_ok=True)

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -162,10 +162,10 @@ class MainWindow(QMainWindow):
     def _init_pages(self):
         """初始化页面并绑定导航"""
         self.page_settings = SettingsPage(self.state)
-        self.page_sender = SenderPage(self.state)
+        self.page_sender = SenderPage(self.state, self.rt.history_manager)
         self.page_editor = EditorPage(self.state)
-        self.page_monitor = MonitorPage(self.state)
-        self.page_history = HistoryPage(self.state)
+        self.page_monitor = MonitorPage(self.state, self.rt.history_manager)
+        self.page_history = HistoryPage(self.state, self.rt.history_manager)
 
         # 定义页面列表
         pages = [

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
 
 from danmaku_sender.types.models.common import MonitorStats, VideoTarget
 from danmaku_sender.runtime.app_state import AppState
+from danmaku_sender.repo.history_manager import HistoryManager
 
 from danmaku_sender.controller.monitor_controller import MonitorController
 from .framework.binder import UIBinder
@@ -21,12 +22,12 @@ from .framework.style_loader import get_svg_icon
 class MonitorPage(QWidget):
     statsUpdated = Signal(dict)
 
-    def __init__(self, state: AppState):
+    def __init__(self, state: AppState, history_manager: HistoryManager):
         super().__init__()
         self.state = state
         self.logger = logging.getLogger("App.Monitor.UI")
 
-        self.monitor_controller = MonitorController(self)
+        self.monitor_controller = MonitorController(history_manager, self)
 
         self._create_ui()
         self._connect_signals()

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -19,6 +19,7 @@ from danmaku_sender.service.sender import SendingContext
 from danmaku_sender.types.models.video import VideoInfo
 from danmaku_sender.types.models.common import VideoTarget, UnsentDanmakusRecord
 from danmaku_sender.runtime.app_state import AppState
+from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.utils.string_utils import parse_bilibili_link
 from danmaku_sender.utils.time_utils import format_duration
 from danmaku_sender.ui.common.notification import send_windows_notification
@@ -27,13 +28,13 @@ from danmaku_sender.ui.common.notification import send_windows_notification
 class SenderPage(QWidget):
     progressUpdated = Signal(int, int, float)
 
-    def __init__(self, state: AppState):
+    def __init__(self, state: AppState, history_manager: HistoryManager):
         super().__init__()
         self.state = state
         self.logger = logging.getLogger("App.Sender.UI")
         self._pending_part_index: int | None = None
         self.video_controller = VideoController(self)
-        self.sender_controller = SenderController(state, self)
+        self.sender_controller = SenderController(state, history_manager, self)
 
         self._create_ui()
         self._connect_signals()


### PR DESCRIPTION
- 移除单例模式（__new__、_instance、initialize）
- 构造函数改为 HistoryManager(db_path)
- Runtime 创建实例并逐层注入到 service/controller
- history_controller 不再直接构造 HistoryManager

## Summary by Sourcery

在整个运行时、控制器、服务和 UI 页面中，通过构造函数依赖注入的方式传递 `HistoryManager`，将其从单例模式中解耦，同时在 `AppInfo.Paths` 中集中管理应用数据路径。

Bug Fixes:
- 通过 `AppInfo.Paths` 预先创建应用数据目录，避免在各处零散创建目录以及可能出现的路径不一致问题。

Enhancements:
- 用显式实例构造（使用 `db_path` 参数）替换 `HistoryManager` 的单例初始化，并通过 `Runtime` 将该实例注入到 sender、monitor 以及历史相关的控制器和页面中。
- 将配置、账户、日志和历史数据库的文件路径处理重构为集中定义在 `AppInfo.Paths` 常量中，以统一标准化应用数据目录。
- 更新 monitor 和 sender 的处理流程，使其接受共享的 `HistoryManager` 实例，而不是各自创建单例，从而使历史操作与新的依赖注入方案保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple HistoryManager from its singleton pattern and wire it via constructor-based dependency injection throughout the runtime, controllers, services, and UI pages, while centralizing app data paths in AppInfo.Paths.

Bug Fixes:
- Ensure application data directories are created up front via AppInfo.Paths to avoid scattered directory creation and potential path inconsistencies.

Enhancements:
- Replace HistoryManager singleton initialization with explicit instance construction using a db_path parameter and inject it through Runtime into sender, monitor, and history controllers and pages.
- Refactor file path handling for config, accounts, logs, and history DB into centralized AppInfo.Paths constants to standardize application data directories.
- Update monitor and sender pipelines to accept a shared HistoryManager instance instead of creating their own singleton, aligning history operations with the new DI approach.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在整个运行时、控制器、服务和 UI 页面中，通过构造函数依赖注入的方式传递 `HistoryManager`，将其从单例模式中解耦，同时在 `AppInfo.Paths` 中集中管理应用数据路径。

Bug Fixes:
- 通过 `AppInfo.Paths` 预先创建应用数据目录，避免在各处零散创建目录以及可能出现的路径不一致问题。

Enhancements:
- 用显式实例构造（使用 `db_path` 参数）替换 `HistoryManager` 的单例初始化，并通过 `Runtime` 将该实例注入到 sender、monitor 以及历史相关的控制器和页面中。
- 将配置、账户、日志和历史数据库的文件路径处理重构为集中定义在 `AppInfo.Paths` 常量中，以统一标准化应用数据目录。
- 更新 monitor 和 sender 的处理流程，使其接受共享的 `HistoryManager` 实例，而不是各自创建单例，从而使历史操作与新的依赖注入方案保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Decouple HistoryManager from its singleton pattern and wire it via constructor-based dependency injection throughout the runtime, controllers, services, and UI pages, while centralizing app data paths in AppInfo.Paths.

Bug Fixes:
- Ensure application data directories are created up front via AppInfo.Paths to avoid scattered directory creation and potential path inconsistencies.

Enhancements:
- Replace HistoryManager singleton initialization with explicit instance construction using a db_path parameter and inject it through Runtime into sender, monitor, and history controllers and pages.
- Refactor file path handling for config, accounts, logs, and history DB into centralized AppInfo.Paths constants to standardize application data directories.
- Update monitor and sender pipelines to accept a shared HistoryManager instance instead of creating their own singleton, aligning history operations with the new DI approach.

</details>

</details>