### PR TITLE
refactor(sender): SenderConfig 只通过 Job 传递，移除 Context 和 Pipeline 的冗余存储

### DIFF
--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -157,7 +157,7 @@ class SendTaskWorker(WorkerThread):
         ctx = None
         try:
             with KeepSystemAwake(self.strategy_config.prevent_sleep):
-                pipeline = SendPipeline(self.auth_config, self.strategy_config, self.history_manager)
+                pipeline = SendPipeline(self.auth_config, self.history_manager)
                 job = SendJob(
                     target=self.target,
                     danmakus=self.danmakus,

--- a/src/danmaku_sender/service/sender/context.py
+++ b/src/danmaku_sender/service/sender/context.py
@@ -40,7 +40,6 @@ class SendingContext:
     流水线结束后，将作为最终的统计报告返回给外层调用方。
     """
     total: int                  # 任务总数
-    config: SenderConfig        # 运行配置快照
     target: VideoTarget         # 目标视频信息
 
     # 计数器

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -39,11 +39,9 @@ class SendPipeline:
     def __init__(
         self,
         auth_config: ApiAuthConfig,
-        strategy_config: SenderConfig,
         history_manager: HistoryManager,
     ):
         self.auth_config = auth_config
-        self.strategy_config = strategy_config
         self.history_manager = history_manager
 
     def execute(

--- a/src/danmaku_sender/service/sender/scheduler.py
+++ b/src/danmaku_sender/service/sender/scheduler.py
@@ -6,6 +6,7 @@ from .context import SendingContext, DanmakuFingerprint, SendJob
 from .delay_manager import DelayManager
 
 from danmaku_sender.repo.history_manager import HistoryManager
+from danmaku_sender.config import SenderConfig
 from danmaku_sender.types.models.danmaku import Danmaku
 
 
@@ -26,13 +27,13 @@ class DanmakuScheduler:
         """生成物理指纹，用于识别内容、位置、样式完全一样的重复弹幕"""
         return (dm.msg, dm.progress, dm.mode, dm.fontsize, dm.color)
 
-    def _should_skip(self, dm: Danmaku, ctx: SendingContext) -> bool:
+    def _should_skip(self, dm: Danmaku, ctx: SendingContext, config: SenderConfig) -> bool:
         """
         断点续传：智能去重逻辑
 
         对每个指纹计数，若当前发送序列中该指纹的出现次数 <= 数据库中已成功发送的次数，则跳过。
         """
-        if not ctx.config.skip_sent or not self.history_manager:
+        if not config.skip_sent or not self.history_manager:
             return False
 
         dm_fingerprint = self._get_fingerprint(dm)
@@ -53,15 +54,15 @@ class DanmakuScheduler:
             return True
         return False
 
-    def _check_auto_stop(self, ctx: SendingContext, stop_event: Event) -> bool:
+    def _check_auto_stop(self, ctx: SendingContext, stop_event: Event, config: SenderConfig) -> bool:
         """检查是否满足用户配置的自动终止条件（发满 N 条或运行满 M 分钟）"""
-        if ctx.config.stop_after_count > 0 and ctx.success_count >= ctx.config.stop_after_count:
-            ctx.auto_stop_reason = f"达到数量限制 ({ctx.config.stop_after_count}条)"
+        if config.stop_after_count > 0 and ctx.success_count >= config.stop_after_count:
+            ctx.auto_stop_reason = f"达到数量限制 ({config.stop_after_count}条)"
             stop_event.set()
             return True
 
-        if ctx.config.stop_after_time > 0 and ctx.elapsed_minutes >= ctx.config.stop_after_time:
-            ctx.auto_stop_reason = f"达到时间限制 ({ctx.config.stop_after_time}分钟)"
+        if config.stop_after_time > 0 and ctx.elapsed_minutes >= config.stop_after_time:
+            ctx.auto_stop_reason = f"达到时间限制 ({config.stop_after_time}分钟)"
             stop_event.set()
             return True
 
@@ -77,7 +78,7 @@ class DanmakuScheduler:
         self.logger.info(f"🚀 启动调度流水线... 目标: {job.target.display_string} (CID: {job.target.cid})")
 
         # 初始化统计容器
-        ctx = SendingContext(total=len(job.danmakus), config=job.config, target=job.target)
+        ctx = SendingContext(total=len(job.danmakus), target=job.target)
 
         if not job.danmakus:
             return ctx
@@ -101,7 +102,7 @@ class DanmakuScheduler:
                 job.progress_callback(i + 1, ctx.total)
 
             # --- 查重断点续传 ---
-            if self._should_skip(dm, ctx):
+            if self._should_skip(dm, ctx, job.config):
                 ctx.skipped_count += 1
                 continue
 
@@ -128,7 +129,7 @@ class DanmakuScheduler:
                 ctx.success_count += 1
 
             # --- 检查用户设置的自动终止阀值 ---
-            if self._check_auto_stop(ctx, job.stop_event):
+            if self._check_auto_stop(ctx, job.stop_event, job.config):
                 reason = ctx.auto_stop_reason if ctx.auto_stop_reason else "达到自动停止条件"
                 if i + 1 < ctx.total:
                     ctx.add_unsent(job.danmakus[i+1:], f"自动停止: {reason}")


### PR DESCRIPTION
- SendingContext 去掉 config 字段
- _should_skip/_check_auto_stop 改为显式接收 config 参数
- SendPipeline 去掉 strategy_config 死参数

## Summary by Sourcery

重构发送方调度机制，使其依赖通过 `SendJob` 提供的 `SenderConfig`，而不是将其存储在 `SendingContext` 或 `SendPipeline` 中。

增强内容：
- 从 `SendingContext` 中移除 `SenderConfig`，并让跳过/自动停止检查显式地从 `SendJob` 接收配置。
- 通过移除未使用的 `strategy_config` 参数来简化 `SendPipeline` 的构建过程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor sender scheduling to rely on SenderConfig provided via SendJob rather than storing it in SendingContext or SendPipeline.

Enhancements:
- Remove SenderConfig from SendingContext and make skip/auto-stop checks accept configuration explicitly from the SendJob.
- Simplify SendPipeline construction by dropping the unused strategy_config parameter.

</details>