### PR TITLE
feat(sender): 添加发送前确认对话框

### DIFF
--- a/src/danmaku_sender/types/models/evented_model.py
+++ b/src/danmaku_sender/types/models/evented_model.py
@@ -3,7 +3,7 @@
 配合 UIBinder 实现 Model → Widget 的反向同步。
 """
 
-from typing import Any, Callable
+from typing import Any, Callable, Self
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -51,7 +51,7 @@ class EventedModel(BaseModel):
             if not self._callbacks[field_name]:
                 del self._callbacks[field_name]
 
-    def model_copy(self, **kwargs) -> 'EventedModel':
+    def model_copy(self, **kwargs) -> Self:
         """拷贝时隔离 _callbacks，防止拷贝与原始共享回调注册表"""
         copy = super().model_copy(**kwargs)
         copy._callbacks = {}

--- a/src/danmaku_sender/types/models/evented_model.py
+++ b/src/danmaku_sender/types/models/evented_model.py
@@ -50,3 +50,9 @@ class EventedModel(BaseModel):
             self._callbacks[field_name].remove(callback)
             if not self._callbacks[field_name]:
                 del self._callbacks[field_name]
+
+    def model_copy(self, **kwargs) -> 'EventedModel':
+        """拷贝时隔离 _callbacks，防止拷贝与原始共享回调注册表"""
+        copy = super().model_copy(**kwargs)
+        copy._callbacks = {}
+        return copy

--- a/src/danmaku_sender/ui/framework/binder.py
+++ b/src/danmaku_sender/ui/framework/binder.py
@@ -183,14 +183,19 @@ class UIBinder:
             def _on_model_changed(new_val: Any):
                 w = w_ref()
                 if w is not None:
-                    UIBinder._set_widget_value(w, new_val)
+                    try:
+                        UIBinder._set_widget_value(w, new_val)
+                    except RuntimeError:
+                        # PySide6: Python 包装对象仍存在但底层 C++ 对象已销毁
+                        # 等同于 widget 已死，注销自身
+                        unsub = getattr(model, "unsubscribe", None)
+                        if callable(unsub):
+                            unsub(field_name, _on_model_changed)
                 else:
-                    # widget 已销毁，主动注销自身，防止死回调积压
-                    # 不使用 widget.destroyed 信号：PySide6 退出时解释器先于 Qt 引擎解体，
-                    # destroyed 触发时 model 可能已是 None，会弹 AttributeError
-                    unsubscribe_fn = getattr(model, "unsubscribe", None)
-                    if callable(unsubscribe_fn):
-                        unsubscribe_fn(field_name, _on_model_changed)
+                    # widget 已被 Python GC，主动注销自身，防止死回调积压
+                    unsub = getattr(model, "unsubscribe", None)
+                    if callable(unsub):
+                        unsub(field_name, _on_model_changed)
 
             model.subscribe(field_name, _on_model_changed)
             # 记录当前订阅信息，用于下次重绑时清理

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -676,6 +676,9 @@ class PreSendDialog(QDialog):
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
         self.state = state
+        # 使用临时拷贝，取消时不会污染全局配置
+        self._config_copy = state.sender_config.model_copy()
+
         self.setWindowTitle("发送确认")
         self.setMinimumWidth(420)
         self.setWindowFlags(
@@ -715,21 +718,26 @@ class PreSendDialog(QDialog):
         # 3. 当前账号
         account_group = QGroupBox("当前账号")
         account_layout = QHBoxLayout(account_group)
-        # 从 saved_accounts 中找当前 sessdata 对应的账号名
         account_name = "未知"
         for acc in state.saved_accounts:
             if acc.sessdata == state.sessdata:
                 account_name = acc.name or "未命名"
                 break
-        masked_sessdata = state.sessdata[:4] + "****" + state.sessdata[-4:] if len(state.sessdata) > 8 else "****"
-        account_layout.addWidget(QLabel(f"{account_name} (SESSDATA: {masked_sessdata})"))
+        sessdata = state.sessdata or ""
+        if len(sessdata) > 8:
+            masked = sessdata[:4] + "****" + sessdata[-4:]
+        elif sessdata:
+            masked = "****"
+        else:
+            masked = "(未登录)"
+        account_layout.addWidget(QLabel(f"{account_name} (SESSDATA: {masked})"))
         account_layout.addStretch()
         layout.addWidget(account_group)
 
-        # 4. 发送策略（可编辑，UIBinder 直接修改 state.sender_config）
+        # 4. 发送策略（绑定到临时拷贝，取消时自动丢弃）
         strategy_group = QGroupBox("发送策略")
         strategy_form = QFormLayout(strategy_group)
-        config = state.sender_config
+        config = self._config_copy
 
         # 延时
         delay_layout = QHBoxLayout()
@@ -788,7 +796,7 @@ class PreSendDialog(QDialog):
 
         layout.addWidget(strategy_group)
 
-        # 绑定（直接修改 state.sender_config）
+        # 绑定到临时拷贝
         UIBinder.bind(self.min_delay, config, "min_delay")
         UIBinder.bind(self.max_delay, config, "max_delay")
         UIBinder.bind(self.burst_size, config, "burst_size")
@@ -806,6 +814,12 @@ class PreSendDialog(QDialog):
         btn_layout.addWidget(cancel_btn)
         confirm_btn = QPushButton("确认发送")
         confirm_btn.setObjectName("primaryButton")
-        confirm_btn.clicked.connect(self.accept)
+        confirm_btn.clicked.connect(self._on_confirm)
         btn_layout.addWidget(confirm_btn)
         layout.addLayout(btn_layout)
+
+    def _on_confirm(self):
+        """确认时将临时拷贝写回全局配置"""
+        for field in self._config_copy.model_fields:
+            setattr(self.state.sender_config, field, getattr(self._config_copy, field))
+        self.accept()

--- a/src/danmaku_sender/ui/sender_page.py
+++ b/src/danmaku_sender/ui/sender_page.py
@@ -5,7 +5,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QFormLayout, QLineEdit,
     QPushButton, QComboBox, QLabel, QGroupBox, QTextEdit, QCheckBox,
     QProgressBar, QTabWidget, QSpinBox, QDoubleSpinBox, QFrame,
-    QFileDialog, QMessageBox
+    QFileDialog, QMessageBox, QDialog
 )
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent
 from PySide6.QtCore import Qt, QDateTime, Signal, Slot
@@ -223,10 +223,15 @@ class SenderPage(QWidget):
             QMessageBox.warning(self, "凭证缺失", "请先在【全局设置】页填入 SESSDATA 和 BILI_JCT。")
             return
 
+        # 弹出确认对话框
+        dialog = PreSendDialog(state, self)
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return
+
         # UI 锁定
         self._set_ui_for_task_start()
 
-        # 构造配置
+        # 构造配置（对话框中的 UIBinder 已直接修改 state.sender_config）
         target = VideoTarget(
             bvid=state.video_state.bvid,
             cid=state.video_state.selected_cid,
@@ -663,3 +668,144 @@ class StrategySettingsTabs(QTabWidget):
         self.burst_rest_max.setEnabled(enabled)
         self.stop_count.setEnabled(enabled)
         self.stop_time.setEnabled(enabled)
+
+
+class PreSendDialog(QDialog):
+    """发送前确认对话框：集中展示目标视频、弹幕统计、账号信息和发送策略"""
+
+    def __init__(self, state: AppState, parent=None):
+        super().__init__(parent)
+        self.state = state
+        self.setWindowTitle("发送确认")
+        self.setMinimumWidth(420)
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        # 1. 目标视频
+        video_group = QGroupBox("目标视频")
+        video_form = QFormLayout(video_group)
+        vs = state.video_state
+        video_form.addRow("BV号:", QLabel(vs.bvid))
+        video_form.addRow("标题:", QLabel(vs.video_title))
+        if vs.selected_part_name:
+            video_form.addRow("分P:", QLabel(vs.selected_part_name))
+        layout.addWidget(video_group)
+
+        # 2. 弹幕概览
+        danmaku_group = QGroupBox("弹幕信息")
+        danmaku_layout = QHBoxLayout(danmaku_group)
+        total = len(vs.loaded_danmakus)
+        valid = sum(1 for d in vs.loaded_danmakus if d.is_valid is not False)
+        invalid = sum(1 for d in vs.loaded_danmakus if d.is_valid is False)
+        danmaku_layout.addWidget(QLabel(f"总数: {total} 条"))
+        danmaku_layout.addWidget(QLabel(f"有效: {valid} 条"))
+        if invalid > 0:
+            warn_label = QLabel(f"无效: {invalid} 条")
+            warn_label.setStyleSheet("color: #e74c3c;")
+            danmaku_layout.addWidget(warn_label)
+        danmaku_layout.addStretch()
+        layout.addWidget(danmaku_group)
+
+        # 3. 当前账号
+        account_group = QGroupBox("当前账号")
+        account_layout = QHBoxLayout(account_group)
+        # 从 saved_accounts 中找当前 sessdata 对应的账号名
+        account_name = "未知"
+        for acc in state.saved_accounts:
+            if acc.sessdata == state.sessdata:
+                account_name = acc.name or "未命名"
+                break
+        masked_sessdata = state.sessdata[:4] + "****" + state.sessdata[-4:] if len(state.sessdata) > 8 else "****"
+        account_layout.addWidget(QLabel(f"{account_name} (SESSDATA: {masked_sessdata})"))
+        account_layout.addStretch()
+        layout.addWidget(account_group)
+
+        # 4. 发送策略（可编辑，UIBinder 直接修改 state.sender_config）
+        strategy_group = QGroupBox("发送策略")
+        strategy_form = QFormLayout(strategy_group)
+        config = state.sender_config
+
+        # 延时
+        delay_layout = QHBoxLayout()
+        self.min_delay = QDoubleSpinBox()
+        self.min_delay.setRange(0.1, 60.0)
+        self.min_delay.setSingleStep(0.5)
+        delay_layout.addWidget(self.min_delay)
+        delay_layout.addWidget(QLabel("~"))
+        self.max_delay = QDoubleSpinBox()
+        self.max_delay.setRange(0.1, 60.0)
+        self.max_delay.setSingleStep(0.5)
+        delay_layout.addWidget(self.max_delay)
+        delay_layout.addWidget(QLabel("秒"))
+        delay_layout.addStretch()
+        strategy_form.addRow("随机间隔:", delay_layout)
+
+        # 爆发
+        burst_layout = QHBoxLayout()
+        self.burst_size = QSpinBox()
+        self.burst_size.setRange(0, 100)
+        burst_layout.addWidget(QLabel("每"))
+        burst_layout.addWidget(self.burst_size)
+        burst_layout.addWidget(QLabel("条，休息"))
+        self.burst_rest_min = QDoubleSpinBox()
+        self.burst_rest_min.setRange(0.0, 300.0)
+        self.burst_rest_min.setFixedWidth(60)
+        burst_layout.addWidget(self.burst_rest_min)
+        burst_layout.addWidget(QLabel("~"))
+        self.burst_rest_max = QDoubleSpinBox()
+        self.burst_rest_max.setRange(0.0, 300.0)
+        self.burst_rest_max.setFixedWidth(60)
+        burst_layout.addWidget(self.burst_rest_max)
+        burst_layout.addWidget(QLabel("秒"))
+        burst_layout.addStretch()
+        strategy_form.addRow("爆发模式:", burst_layout)
+
+        # 自动停止
+        stop_layout = QHBoxLayout()
+        self.stop_count = QSpinBox()
+        self.stop_count.setRange(0, 99999)
+        stop_layout.addWidget(QLabel("发满"))
+        stop_layout.addWidget(self.stop_count)
+        stop_layout.addWidget(QLabel("条"))
+        stop_layout.addSpacing(12)
+        self.stop_time = QSpinBox()
+        self.stop_time.setRange(0, 99999)
+        stop_layout.addWidget(QLabel("运行满"))
+        stop_layout.addWidget(self.stop_time)
+        stop_layout.addWidget(QLabel("分钟 (0=不限)"))
+        stop_layout.addStretch()
+        strategy_form.addRow("自动停止:", stop_layout)
+
+        # 断点续传
+        self.skip_sent_cb = QCheckBox("启用断点续传")
+        strategy_form.addRow("", self.skip_sent_cb)
+
+        layout.addWidget(strategy_group)
+
+        # 绑定（直接修改 state.sender_config）
+        UIBinder.bind(self.min_delay, config, "min_delay")
+        UIBinder.bind(self.max_delay, config, "max_delay")
+        UIBinder.bind(self.burst_size, config, "burst_size")
+        UIBinder.bind(self.burst_rest_min, config, "rest_min")
+        UIBinder.bind(self.burst_rest_max, config, "rest_max")
+        UIBinder.bind(self.stop_count, config, "stop_after_count")
+        UIBinder.bind(self.stop_time, config, "stop_after_time")
+        UIBinder.bind(self.skip_sent_cb, config, "skip_sent")
+
+        # 5. 按钮
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel_btn = QPushButton("取消")
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel_btn)
+        confirm_btn = QPushButton("确认发送")
+        confirm_btn.setObjectName("primaryButton")
+        confirm_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(confirm_btn)
+        layout.addLayout(btn_layout)


### PR DESCRIPTION
- 点击发送按钮后弹出确认窗口
- 展示目标视频、弹幕统计、当前账号信息
- 可直接编辑发送策略（延时、爆发、自动停止）
- 确认后才启动发送任务

## 由 Sourcery 生成的摘要

添加发送前确认流程，在启动弹幕发送任务之前需要用户确认。

新功能：
- 引入发送前确认对话框，展示目标视频详情、弹幕统计信息、当前账号信息，以及可编辑的发送策略参数。
- 允许在发送前直接在确认对话框中编辑发送延迟、突发模式、自动停止条件和断点续传选项。

改进：
- 确保在开始发送任务之前，通过确认对话框的数据绑定更新发送器配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在启动发送任务之前，引入一个“发送前确认”流程，用于汇总目标视频、弹幕统计、当前账号以及发送策略。

新功能：
- 添加“发送前确认”对话框，用于展示目标视频详情、弹幕数量、当前账号信息以及可编辑的发送策略参数。
- 允许在开始任务前，直接在确认对话框中编辑发送延迟、爆发模式（burst mode）、自动停止条件以及继续发送选项。

改进：
- 确保在确认对话框中修改的发送配置，仅在用户确认后才应用到全局状态。
- 强化 UI 绑定逻辑，当 Qt 组件已销毁时，通过安全地注销过期订阅来防止回调触发到无效组件，而不是抛出运行时错误。
- 为事件驱动模型的基类扩展一个复制（copy）方法，使不同模型实例之间的回调注册表相互隔离，避免共享订阅。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a pre-send confirmation flow that summarizes the target video, danmaku statistics, current account, and sending strategy before starting a send task.

New Features:
- Add a pre-send confirmation dialog that displays target video details, danmaku counts, current account info, and editable sending strategy parameters.
- Allow editing of sending delays, burst mode, auto-stop conditions, and resume options directly in the confirmation dialog before starting the task.

Enhancements:
- Ensure sender configuration changes made in the confirmation dialog are applied to the global state only after user confirmation.
- Harden the UI binder against callbacks to destroyed Qt widgets by safely unregistering obsolete subscriptions instead of raising runtime errors.
- Extend the event-driven model base class with a copy method that isolates callback registries between model instances to avoid shared subscriptions.

</details>

新功能：
- 引入预发送确认对话框，在启动发送任务前汇总展示目标视频、弹幕统计信息、当前账号以及可编辑的发送策略。

增强点：
- 更新 UI 绑定器，使其在底层 Qt 组件被销毁时也能安全处理回调，避免过期订阅和运行时错误。
- 为事件驱动的模型基类扩展 `copy` 方法，使原始配置与复制配置之间的回调注册相互隔离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在启动发送任务之前，引入一个“发送前确认”流程，用于汇总目标视频、弹幕统计、当前账号以及发送策略。

新功能：
- 添加“发送前确认”对话框，用于展示目标视频详情、弹幕数量、当前账号信息以及可编辑的发送策略参数。
- 允许在开始任务前，直接在确认对话框中编辑发送延迟、爆发模式（burst mode）、自动停止条件以及继续发送选项。

改进：
- 确保在确认对话框中修改的发送配置，仅在用户确认后才应用到全局状态。
- 强化 UI 绑定逻辑，当 Qt 组件已销毁时，通过安全地注销过期订阅来防止回调触发到无效组件，而不是抛出运行时错误。
- 为事件驱动模型的基类扩展一个复制（copy）方法，使不同模型实例之间的回调注册表相互隔离，避免共享订阅。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a pre-send confirmation flow that summarizes the target video, danmaku statistics, current account, and sending strategy before starting a send task.

New Features:
- Add a pre-send confirmation dialog that displays target video details, danmaku counts, current account info, and editable sending strategy parameters.
- Allow editing of sending delays, burst mode, auto-stop conditions, and resume options directly in the confirmation dialog before starting the task.

Enhancements:
- Ensure sender configuration changes made in the confirmation dialog are applied to the global state only after user confirmation.
- Harden the UI binder against callbacks to destroyed Qt widgets by safely unregistering obsolete subscriptions instead of raising runtime errors.
- Extend the event-driven model base class with a copy method that isolates callback registries between model instances to avoid shared subscriptions.

</details>

</details>

</details>