### PR TITLE
refactor(config): assets 路径改为向上遍历查找，兼容 Nuitka 打包目录结构

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # B站弹幕发射器 (BiliDanmakuSender)
 
 <p align="center">
-  <img src="https://img.shields.io/github/v/tag/TouhouGleaners/danmaku-sender?label=Pre-Release&color=orange" alt="Pre-release">
+  <img src="https://img.shields.io/github/v/tag/TouhouGleaners/danmaku-sender?filter=v*&label=Pre-Release&color=orange" alt="Pre-release">
   <img src="https://img.shields.io/github/v/release/TouhouGleaners/danmaku-sender?label=Release&color=bright-green" alt="Release">
   <img src="https://img.shields.io/github/downloads/TouhouGleaners/danmaku-sender/total?label=Downloads" alt="Total Downloads">
   <img src="https://img.shields.io/badge/Python-3.12+-blue.svg" alt="Python 3.12+">

--- a/src/danmaku_sender/config/app_meta.py
+++ b/src/danmaku_sender/config/app_meta.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from platformdirs import user_data_dir
 
 from danmaku_sender._version import __version__
+from danmaku_sender.utils.path_utils import find_assets_dir
 
 
 # 应用数据目录（import 时计算，运行时不变）
@@ -27,8 +28,8 @@ class AppInfo:
         LOGS = _DATA_DIR / "logs"
         ACCOUNTS = _DATA_DIR / "accounts.json"
 
-        # 应用资源目录（只读）
-        ASSETS = Path(__file__).resolve().parents[3] / "assets"
+        # 应用资源目录（只读，向上遍历查找，兼容开发和 Nuitka 打包）
+        ASSETS = find_assets_dir(__file__)
 
 
 class UI:

--- a/src/danmaku_sender/utils/path_utils.py
+++ b/src/danmaku_sender/utils/path_utils.py
@@ -1,0 +1,26 @@
+"""路径工具函数"""
+
+from pathlib import Path
+
+
+def find_assets_dir(anchor_file: str) -> Path:
+    """从指定文件向上遍历查找 assets 目录，兼容开发环境和 Nuitka 打包。
+
+    Args:
+        anchor_file: 起始文件的 __file__ 值，通常传 __file__ 即可。
+
+    Returns:
+        找到的 assets 目录路径。
+    """
+    current_path = Path(anchor_file).resolve().parent
+
+    for _ in range(5):
+        candidate = current_path / "assets"
+        if candidate.is_dir():
+            return candidate
+
+        if current_path.parent == current_path:
+            break
+        current_path = current_path.parent
+
+    return Path(anchor_file).resolve().parents[3] / "assets"


### PR DESCRIPTION
## Summary by Sourcery

更新资源目录解析方式，使其在开发环境和 Nuitka 打包布局下都更加稳健。

Bug Fixes:
- 通过从当前文件向上遍历以定位资源目录来修复资源路径检测问题，确保与 Nuitka 生成的目录结构兼容。

Enhancements:
- 引入可复用的路径工具，用于从锚点文件定位资源目录。
- 调整 README 预发布徽章，使其仅考虑匹配版本模式的标签。

Documentation:
- 更新 README 中用于预发布徽章的 shield 配置，以反映基于版本标签的过滤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update asset directory resolution to be robust across development and Nuitka packaging layouts.

Bug Fixes:
- Fix asset path detection by traversing upwards from the current file to locate the assets directory, ensuring compatibility with Nuitka-generated directory structures.

Enhancements:
- Introduce a reusable path utility for locating the assets directory from an anchor file.
- Adjust README pre-release badge to only consider tags matching the version pattern.

Documentation:
- Update README shield configuration for the pre-release badge to reflect version-tag filtering.

</details>