### PR TITLE
feat(ui): 添加全局快捷键 Ctrl+O 打开文件、Ctrl+Enter 发送、Ctrl+, 设置

### DIFF
--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import (
     QMainWindow, QWidget, QMessageBox, QHBoxLayout, QVBoxLayout, QFrame, QApplication,
     QListWidget, QListWidgetItem, QStackedWidget, QLabel, QSystemTrayIcon, QMenu
 )
-from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices
+from PySide6.QtGui import QAction, QCloseEvent, QDesktopServices, QShortcut, QKeySequence
 from PySide6.QtCore import Qt, QUrl, QTimer, QSize, QEvent, Slot
 
 from .framework.image_processor import QtImageProcessor
@@ -55,6 +55,7 @@ class MainWindow(QMainWindow):
         # UI 初始化
         self._create_ui()
         self._init_pages()
+        self._init_shortcuts()
         self._create_menu_bar()
         self._init_system_tray()
 
@@ -186,11 +187,30 @@ class MainWindow(QMainWindow):
         self.user_widget.setCursor(Qt.CursorShape.PointingHandCursor)
         self.user_widget.mousePressEvent = lambda e: self._open_account_dialog()
 
+    def _init_shortcuts(self):
+        """初始化全局快捷键"""
+        # Ctrl+O: 打开弹幕文件
+        sc_open = QShortcut(QKeySequence.StandardKey.Open, self)
+        sc_open.activated.connect(self.page_sender._select_file)
+
+        # Ctrl+Enter: 开始发送
+        sc_send = QShortcut(QKeySequence(Qt.Key.Key_Return | Qt.KeyboardModifier.ControlModifier), self)
+        sc_send.activated.connect(self.page_sender._toggle_task)
+
+        # Ctrl+,: 打开全局设置
+        sc_settings = QShortcut(QKeySequence(Qt.Key.Key_Comma | Qt.KeyboardModifier.ControlModifier), self)
+        sc_settings.activated.connect(lambda: self.sidebar.setCurrentRow(0))
+
     def _create_menu_bar(self):
         menu_bar = self.menuBar()
 
         # --- 文件菜单 ---
         file_menu = menu_bar.addMenu("文件")
+
+        open_xml_action = QAction("打开弹幕文件", self)
+        open_xml_action.setShortcut(QKeySequence.StandardKey.Open)
+        open_xml_action.triggered.connect(self.page_sender._select_file)
+        file_menu.addAction(open_xml_action)
 
         open_log_action = QAction("打开日志文件夹", self)
         open_log_action.triggered.connect(self._open_log_folder)

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -190,27 +190,22 @@ class MainWindow(QMainWindow):
     def _init_shortcuts(self):
         """初始化全局快捷键"""
         # Ctrl+O: 打开弹幕文件
-        sc_open = QShortcut(QKeySequence.StandardKey.Open, self)
-        sc_open.activated.connect(self.page_sender._select_file)
+        self._sc_open = QShortcut(QKeySequence.StandardKey.Open, self)
+        self._sc_open.activated.connect(self.page_sender._select_file)
 
         # Ctrl+Enter: 开始发送
-        sc_send = QShortcut(QKeySequence(Qt.Key.Key_Return | Qt.KeyboardModifier.ControlModifier), self)
-        sc_send.activated.connect(self.page_sender._toggle_task)
+        self._sc_send = QShortcut(QKeySequence(Qt.Key.Key_Return | Qt.KeyboardModifier.ControlModifier), self)
+        self._sc_send.activated.connect(self.page_sender._toggle_task)
 
         # Ctrl+,: 打开全局设置
-        sc_settings = QShortcut(QKeySequence(Qt.Key.Key_Comma | Qt.KeyboardModifier.ControlModifier), self)
-        sc_settings.activated.connect(lambda: self.sidebar.setCurrentRow(0))
+        self._sc_settings = QShortcut(QKeySequence(Qt.Key.Key_Comma | Qt.KeyboardModifier.ControlModifier), self)
+        self._sc_settings.activated.connect(lambda: self.sidebar.setCurrentRow(0))
 
     def _create_menu_bar(self):
         menu_bar = self.menuBar()
 
         # --- 文件菜单 ---
         file_menu = menu_bar.addMenu("文件")
-
-        open_xml_action = QAction("打开弹幕文件", self)
-        open_xml_action.setShortcut(QKeySequence.StandardKey.Open)
-        open_xml_action.triggered.connect(self.page_sender._select_file)
-        file_menu.addAction(open_xml_action)
 
         open_log_action = QAction("打开日志文件夹", self)
         open_log_action.triggered.connect(self._open_log_folder)


### PR DESCRIPTION
## Summary by Sourcery

在主窗口中新增全局键盘快捷键，用于触发打开文件、发送和访问设置等核心操作。

新功能：
- 引入全局快捷键 Ctrl+O，可直接在主窗口中打开弹幕文件。
- 引入全局快捷键 Ctrl+Enter，可用于开始或切换发送状态。
- 引入全局快捷键 Ctrl+,，用于打开全局设置页面。

改进：
- 将打开文件的快捷键接入标准的 “Open” 键序列，以提升界面的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add global keyboard shortcuts in the main window to trigger core actions for opening files, sending, and accessing settings.

New Features:
- Introduce global Ctrl+O shortcut to open danmaku files from the main window.
- Introduce global Ctrl+Enter shortcut to start or toggle the sending state.
- Introduce global Ctrl+, shortcut to open the global settings page.

Enhancements:
- Wire the file open shortcut to use the standard "Open" key sequence for consistency in the UI.

</details>

新功能：
- 在主窗口中引入全局快捷键：使用 Ctrl+O 打开弹幕文件，使用 Ctrl+Enter 开始或切换发送状态，使用 Ctrl+, 打开全局设置。

增强内容：
- 在“文件”菜单中添加专用操作，以使用标准的“打开”快捷键来打开弹幕文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在主窗口中新增全局键盘快捷键，用于触发打开文件、发送和访问设置等核心操作。

新功能：
- 引入全局快捷键 Ctrl+O，可直接在主窗口中打开弹幕文件。
- 引入全局快捷键 Ctrl+Enter，可用于开始或切换发送状态。
- 引入全局快捷键 Ctrl+,，用于打开全局设置页面。

改进：
- 将打开文件的快捷键接入标准的 “Open” 键序列，以提升界面的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add global keyboard shortcuts in the main window to trigger core actions for opening files, sending, and accessing settings.

New Features:
- Introduce global Ctrl+O shortcut to open danmaku files from the main window.
- Introduce global Ctrl+Enter shortcut to start or toggle the sending state.
- Introduce global Ctrl+, shortcut to open the global settings page.

Enhancements:
- Wire the file open shortcut to use the standard "Open" key sequence for consistency in the UI.

</details>

</details>