### PR TITLE
feat(burst): 爆发模式添加 checkbox 开关，替代隐式的数字判断

### DIFF
--- a/src/danmaku_sender/config/sender_config.py
+++ b/src/danmaku_sender/config/sender_config.py
@@ -12,6 +12,7 @@ class SenderConfig(EventedModel):
     max_delay: float = Field(default=8.5, ge=0.1)
 
     # 爆发模式
+    burst_enabled: bool = False
     burst_size: int = Field(default=3, ge=0)
     rest_min: float = Field(default=40.0, ge=0.0)
     rest_max: float = Field(default=45.0, ge=0.0)
@@ -32,6 +33,6 @@ class SenderConfig(EventedModel):
         """业务逻辑级校验：最小不能大于最大"""
         if self.min_delay > self.max_delay:
             raise ValueError("最小延迟不能大于最大延迟")
-        if self.burst_size > 1 and self.rest_min > self.rest_max:
+        if self.burst_enabled and self.rest_min > self.rest_max:
             raise ValueError("爆发休息的最小值不能大于最大值")
         return self

--- a/src/danmaku_sender/config/sender_config.py
+++ b/src/danmaku_sender/config/sender_config.py
@@ -13,7 +13,7 @@ class SenderConfig(EventedModel):
 
     # 爆发模式
     burst_enabled: bool = False
-    burst_size: int = Field(default=3, ge=0)
+    burst_size: int = Field(default=3, ge=2)
     rest_min: float = Field(default=40.0, ge=0.0)
     rest_max: float = Field(default=45.0, ge=0.0)
 

--- a/src/danmaku_sender/service/sender/delay_manager.py
+++ b/src/danmaku_sender/service/sender/delay_manager.py
@@ -13,17 +13,20 @@ class DelayManager:
         self,
         normal_min: float,
         normal_max: float,
+        burst_enabled: bool = False,
         burst_size: int = 0,
         rest_min: float = 0,
-        rest_max: float = 0
+        rest_max: float = 0,
     ):
         """
         Args:
             normal_min (float): 普通间隔的随机下界（秒）
             normal_max (float): 普通间隔的随机上界（秒）
-            burst_size (int): 爆发阈值，每发 N 条触发一次长休息。<=1 时表示禁用爆发模式。
+            burst_enabled (bool): 是否启用爆发模式。
+            burst_size (int): 爆发阈值，每发 N 条触发一次长休息。
             rest_min (float): 休息时间的随机下界（秒）
             rest_max (float): 休息时间的随机上界（秒）
+            burst_enabled (bool): 是否启用爆发模式。
         """
         self.logger = logging.getLogger("App.Sender.Delay")
 
@@ -32,6 +35,7 @@ class DelayManager:
         self.normal_max = normal_max
 
         # 爆发模式配置
+        self.burst_enabled = burst_enabled
         self.burst_size = burst_size
         self.rest_min = rest_min
         self.rest_max = rest_max
@@ -39,10 +43,10 @@ class DelayManager:
         # 内部计数器: 记录当前周期内已度过了多少次发送延时
         self._current_count = 0
 
-        if self.burst_size > 1:
+        if self.burst_enabled:
             self.logger.info(f"🚀 爆发模式已启用: 每 {self.burst_size} 条休息 {self.rest_min}-{self.rest_max} 秒")
         else:
-            self.logger.debug(f"爆发模式未启用 (阈值: {self.burst_size})")
+            self.logger.debug("爆发模式未启用")
 
     def wait_and_check_stop(self, stop_event: Event) -> bool:
         """
@@ -59,7 +63,7 @@ class DelayManager:
 
         # 判断本轮是短休还是长休
         is_long_rest = False
-        if self.burst_size > 1 and (self._current_count % self.burst_size == 0):
+        if self.burst_enabled and (self._current_count % self.burst_size == 0):
             is_long_rest = True
 
         # 计算
@@ -78,7 +82,7 @@ class DelayManager:
         return False
 
     @staticmethod
-    def calc_eta(attempted: int, total: int, burst_size: int, avg_normal: float, avg_rest: float) -> float:
+    def calc_eta(attempted: int, total: int, burst_enabled: bool, burst_size: int, avg_normal: float, avg_rest: float) -> float:
         """
         计算剩余等待时间 (O(1))。
 
@@ -87,8 +91,8 @@ class DelayManager:
         2. 延时的物理索引从 1 开始（第 k 条弹幕发完后的延时索引为 k）。
         3. 仅当延时索引能被 burst_size 整除时，触发大休息 (avg_rest)。
         """
-        # 防御性校验：避免除零及负数异常
-        if burst_size <= 0:
+        # 未启用爆发模式时，视为无爆发
+        if not burst_enabled:
             burst_size = 1
 
         # 统一处理 0 和 1 进度：

--- a/src/danmaku_sender/service/sender/delay_manager.py
+++ b/src/danmaku_sender/service/sender/delay_manager.py
@@ -14,7 +14,7 @@ class DelayManager:
         normal_min: float,
         normal_max: float,
         burst_enabled: bool = False,
-        burst_size: int = 0,
+        burst_size: int = 3,
         rest_min: float = 0,
         rest_max: float = 0,
     ):
@@ -26,7 +26,6 @@ class DelayManager:
             burst_size (int): 爆发阈值，每发 N 条触发一次长休息。
             rest_min (float): 休息时间的随机下界（秒）
             rest_max (float): 休息时间的随机上界（秒）
-            burst_enabled (bool): 是否启用爆发模式。
         """
         self.logger = logging.getLogger("App.Sender.Delay")
 

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -107,6 +107,7 @@ class SendPipeline:
         return DelayManager.calc_eta(
             attempted=attempted,
             total=total,
+            burst_enabled=cfg.burst_enabled,
             burst_size=cfg.burst_size,
             avg_normal=avg_normal,
             avg_rest=avg_rest,

--- a/src/danmaku_sender/service/sender/scheduler.py
+++ b/src/danmaku_sender/service/sender/scheduler.py
@@ -86,7 +86,8 @@ class DanmakuScheduler:
         # 初始化时钟管理器
         delay_manager = DelayManager(
             normal_min=job.config.min_delay, normal_max=job.config.max_delay,
-            burst_size=job.config.burst_size, rest_min=job.config.rest_min, rest_max=job.config.rest_max
+            burst_enabled=job.config.burst_enabled, burst_size=job.config.burst_size,
+            rest_min=job.config.rest_min, rest_max=job.config.rest_max,
         )
 
         if job.progress_callback:

--- a/src/danmaku_sender/ui/sender/components/dialogs.py
+++ b/src/danmaku_sender/ui/sender/components/dialogs.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import (
-    QVBoxLayout, QHBoxLayout, QFormLayout,
+    QVBoxLayout, QHBoxLayout, QFormLayout, QWidget,
     QPushButton, QLabel, QGroupBox, QCheckBox,
     QSpinBox, QDoubleSpinBox, QDialog
 )
@@ -115,9 +115,15 @@ class PreSendDialog(QDialog):
         form.addRow("随机间隔:", delay_layout)
 
         # 爆发模式
+        self.burst_enabled_cb = QCheckBox("启用爆发模式")
+        self.burst_enabled_cb.setToolTip("勾选后每发 N 条自动休息一段时间")
+        self.burst_enabled_cb.toggled.connect(self._on_burst_toggled)
+        form.addRow("", self.burst_enabled_cb)
+
         burst_layout = QHBoxLayout()
         self.burst_size = QSpinBox()
-        self.burst_size.setRange(0, 100)
+        self.burst_size.setRange(2, 100)
+        self.burst_size.setValue(3)
         burst_layout.addWidget(QLabel("每"))
         burst_layout.addWidget(self.burst_size)
         burst_layout.addWidget(QLabel("条，休息"))
@@ -132,7 +138,9 @@ class PreSendDialog(QDialog):
         burst_layout.addWidget(self.burst_rest_max)
         burst_layout.addWidget(QLabel("秒"))
         burst_layout.addStretch()
-        form.addRow("爆发模式:", burst_layout)
+        form.addRow("爆发参数:", burst_layout)
+
+        self._burst_controls: list[QWidget] = [self.burst_size, self.burst_rest_min, self.burst_rest_max]
 
         # 自动停止
         stop_layout = QHBoxLayout()
@@ -157,6 +165,7 @@ class PreSendDialog(QDialog):
         # 绑定到临时拷贝
         UIBinder.bind(self.min_delay, config, "min_delay")
         UIBinder.bind(self.max_delay, config, "max_delay")
+        UIBinder.bind(self.burst_enabled_cb, config, "burst_enabled")
         UIBinder.bind(self.burst_size, config, "burst_size")
         UIBinder.bind(self.burst_rest_min, config, "rest_min")
         UIBinder.bind(self.burst_rest_max, config, "rest_max")
@@ -164,7 +173,15 @@ class PreSendDialog(QDialog):
         UIBinder.bind(self.stop_time, config, "stop_after_time")
         UIBinder.bind(self.skip_sent_cb, config, "skip_sent")
 
+        # 初始化爆发控件状态
+        self._on_burst_toggled(config.burst_enabled)
+
         return group
+
+    def _on_burst_toggled(self, checked: bool):
+        """爆发模式开关切换时，启用/禁用相关控件"""
+        for ctrl in self._burst_controls:
+            ctrl.setEnabled(checked)
 
     def _create_buttons(self) -> QHBoxLayout:
         """底部确认/取消按钮"""

--- a/src/danmaku_sender/ui/sender/components/strategy_tabs.py
+++ b/src/danmaku_sender/ui/sender/components/strategy_tabs.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import (
-    QWidget, QHBoxLayout, QLabel, QTabWidget,
+    QWidget, QHBoxLayout, QLabel, QTabWidget, QCheckBox,
     QSpinBox, QDoubleSpinBox, QFrame
 )
 
@@ -44,11 +44,16 @@ class StrategySettingsTabs(QTabWidget):
         delay_layout.addSpacing(15)
 
         # 爆发模式
-        delay_layout.addWidget(QLabel("爆发模式: 每"))
+        self.burst_enabled_cb = QCheckBox("爆发模式")
+        self.burst_enabled_cb.setToolTip("勾选启用爆发模式：每发 N 条后自动休息一段时间")
+        self.burst_enabled_cb.toggled.connect(self._on_burst_toggled)
+        delay_layout.addWidget(self.burst_enabled_cb)
+
+        delay_layout.addWidget(QLabel("每"))
 
         self.burst_size = QSpinBox()
-        self.burst_size.setRange(0, 100)
-        self.burst_size.setToolTip("0 或 1 表示关闭爆发模式")
+        self.burst_size.setRange(2, 100)
+        self.burst_size.setValue(3)
         delay_layout.addWidget(self.burst_size)
 
         delay_layout.addWidget(QLabel("条，休息"))
@@ -68,6 +73,10 @@ class StrategySettingsTabs(QTabWidget):
         delay_layout.addWidget(self.burst_rest_max)
 
         delay_layout.addWidget(QLabel("秒"))
+
+        self._burst_controls: list[QWidget] = [
+            self.burst_size, self.burst_rest_min, self.burst_rest_max
+        ]
 
         delay_layout.addStretch()
         self.addTab(delay_tab, "发送延迟")
@@ -103,6 +112,11 @@ class StrategySettingsTabs(QTabWidget):
 
         self.addTab(stop_tab, "自动终止")
 
+    def _on_burst_toggled(self, checked: bool):
+        """爆发模式开关切换时，启用/禁用相关控件"""
+        for ctrl in self._burst_controls:
+            ctrl.setEnabled(checked)
+
     def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
         config = self.state.sender_config
@@ -112,6 +126,7 @@ class StrategySettingsTabs(QTabWidget):
         UIBinder.bind(self.max_delay, config, "max_delay")
 
         # 爆发模式
+        UIBinder.bind(self.burst_enabled_cb, config, "burst_enabled")
         UIBinder.bind(self.burst_size, config, "burst_size")
         UIBinder.bind(self.burst_rest_min, config, "rest_min")
         UIBinder.bind(self.burst_rest_max, config, "rest_max")
@@ -120,14 +135,20 @@ class StrategySettingsTabs(QTabWidget):
         UIBinder.bind(self.stop_count, config, "stop_after_count")
         UIBinder.bind(self.stop_time, config, "stop_after_time")
 
+        # 初始化爆发控件状态
+        self._on_burst_toggled(self.burst_enabled_cb.isChecked())
+
     def set_inputs_locked(self, locked: bool):
         """供主控调用的防误触锁"""
         enabled = not locked
 
         self.min_delay.setEnabled(enabled)
         self.max_delay.setEnabled(enabled)
-        self.burst_size.setEnabled(enabled)
-        self.burst_rest_min.setEnabled(enabled)
-        self.burst_rest_max.setEnabled(enabled)
+        self.burst_enabled_cb.setEnabled(enabled)
+
+        burst_enabled = self.burst_enabled_cb.isChecked() and enabled
+        for ctrl in self._burst_controls:
+            ctrl.setEnabled(burst_enabled)
+
         self.stop_count.setEnabled(enabled)
         self.stop_time.setEnabled(enabled)


### PR DESCRIPTION
## Summary by Sourcery

在发送器中引入一个显式复选框，用于启用或禁用突发发送模式，并将该配置在 UI、配置模型、延迟管理以及 ETA（预计完成时间）计算中进行传递与应用。

New Features:
- 在主发送器 UI 和策略对话框中新增专用复选框控件，用于切换突发模式的开启和关闭。
- 在发送器配置中引入布尔类型的 `burst_enabled` 标志位，并将其接入发送调度器和延迟管理器。

Enhancements:
- 根据突发模式复选框的状态，在主 UI 和对话框中启用或禁用与突发相关的参数控件。
- 优化突发模式的默认值与校验逻辑：要求最小突发大小为 2，并将休息间隔检查与 `burst_enabled` 标志位关联起来。
- 更新延迟和 ETA 逻辑，使用显式的 `burst_enabled` 标志位替代过去通过 `burst_size` 值来推断突发模式的做法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an explicit checkbox to enable or disable burst sending mode and propagate this configuration through the UI, config model, delay management, and ETA calculation.

New Features:
- Add a dedicated checkbox control in the main sender UI and strategy dialog to toggle burst mode on and off.
- Introduce a boolean burst_enabled flag in the sender configuration and wire it into the sending scheduler and delay manager.

Enhancements:
- Disable and enable burst-related parameter controls based on the burst mode checkbox state in both the main UI and dialog.
- Refine burst mode defaults and validation by requiring a minimum burst size of 2 and tying rest interval checks to the burst_enabled flag.
- Update delay and ETA logic to use the explicit burst_enabled flag instead of inferring burst mode from burst_size values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在发送器中引入一个显式复选框，用于启用或禁用突发发送模式，并将该配置在 UI、配置模型、延迟管理以及 ETA（预计完成时间）计算中进行传递与应用。

New Features:
- 在主发送器 UI 和策略对话框中新增专用复选框控件，用于切换突发模式的开启和关闭。
- 在发送器配置中引入布尔类型的 `burst_enabled` 标志位，并将其接入发送调度器和延迟管理器。

Enhancements:
- 根据突发模式复选框的状态，在主 UI 和对话框中启用或禁用与突发相关的参数控件。
- 优化突发模式的默认值与校验逻辑：要求最小突发大小为 2，并将休息间隔检查与 `burst_enabled` 标志位关联起来。
- 更新延迟和 ETA 逻辑，使用显式的 `burst_enabled` 标志位替代过去通过 `burst_size` 值来推断突发模式的做法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an explicit checkbox to enable or disable burst sending mode and propagate this configuration through the UI, config model, delay management, and ETA calculation.

New Features:
- Add a dedicated checkbox control in the main sender UI and strategy dialog to toggle burst mode on and off.
- Introduce a boolean burst_enabled flag in the sender configuration and wire it into the sending scheduler and delay manager.

Enhancements:
- Disable and enable burst-related parameter controls based on the burst mode checkbox state in both the main UI and dialog.
- Refine burst mode defaults and validation by requiring a minimum burst size of 2 and tying rest interval checks to the burst_enabled flag.
- Update delay and ETA logic to use the explicit burst_enabled flag instead of inferring burst mode from burst_size values.

</details>

</details>