### PR TITLE
fix: 更新检查跳过 Nightly-Build 等非版本号 release，遍历最近 5 个 release 寻找有效版本

### DIFF
--- a/src/danmaku_sender/repo/github_client.py
+++ b/src/danmaku_sender/repo/github_client.py
@@ -26,14 +26,14 @@ class UpdateChecker:
             session.trust_env = False
             session.proxies = {}
 
-        api_url = f"{Links.GITHUB_API_RELEASES}?per_page=1"
+        api_url = f"{Links.GITHUB_API_RELEASES}?per_page=5"
         logger.info("正在连接 GitHub 检查更新...")
 
         response = session.get(api_url, timeout=10)
         response.raise_for_status()
 
         try:
-            data_list = response.json()
+            data_list: list[dict] = response.json()
         except ValueError:
             logger.warning("GitHub API 返回了非 JSON 数据")
             return UpdateInfo(False)
@@ -42,21 +42,29 @@ class UpdateChecker:
             logger.warning("未找到任何发布信息")
             return UpdateInfo(False)
 
-        data: dict = data_list[0]
-        remote_tag = data.get("tag_name", "").lstrip("v")
-        release_notes = data.get("body") or "暂无更新日志"
-        release_url = data.get("html_url", Links.GITHUB_REPO)
-
         try:
             local_ver = version.parse(current_version)
-            remote_ver = version.parse(remote_tag)
-        except Exception as e:
-            logger.warning(f"版本号解析失败: {e}")
+        except version.InvalidVersion:
+            logger.debug(f"当前版本号非标准格式 ({current_version})，跳过更新检查")
             return UpdateInfo(False)
 
-        if remote_ver > local_ver:
-            logger.info(f"发现新版本: v{remote_tag}")
-            return UpdateInfo(True, remote_tag, release_notes, release_url)
-        else:
-            logger.info(f"当前已是最新版本 ({local_ver})")
-            return UpdateInfo(False)
+        # 跳过 Nightly-Build 等非版本号 tag，找第一个有效的正式版本
+        for data in data_list:
+            remote_tag = data.get("tag_name", "").lstrip("v")
+            try:
+                remote_ver = version.parse(remote_tag)
+            except version.InvalidVersion:
+                continue
+
+            release_notes = data.get("body") or "暂无更新日志"
+            release_url = data.get("html_url", Links.GITHUB_REPO)
+
+            if remote_ver > local_ver:
+                logger.info(f"发现新版本: v{remote_tag}")
+                return UpdateInfo(True, remote_tag, release_notes, release_url)
+            else:
+                logger.info(f"当前已是最新版本 ({local_ver})")
+                return UpdateInfo(False)
+
+        logger.info("未找到有效的版本发布信息")
+        return UpdateInfo(False)


### PR DESCRIPTION
## Summary by Sourcery

改进 GitHub 发布更新检查机制，以处理非标准标签，并在多个最近的发布版本中搜索有效的更新版本。

新功能：
- 在检查更新时支持跳过 Nightly-Build 以及其他不符合语义化版本规范的发布版本。
- 在最新的五个 GitHub 发布版本中进行搜索，以找到用于更新比较的第一个有效版本。

错误修复：
- 当当前版本字符串或远程标签不是有效的语义化版本时，避免出现崩溃或错误行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve GitHub release update checking to handle non-standard tags and search multiple recent releases for a valid newer version.

New Features:
- Support skipping Nightly-Build and other non-semantic-version releases when checking for updates.
- Search up to the latest five GitHub releases to find the first valid version for update comparison.

Bug Fixes:
- Avoid crashes or incorrect behavior when the current version string or remote tags are not valid semantic versions.

</details>