### PR TITLE
fix(ci): Nightly Build 清理旧 assets + 构建日期改为北京时间

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,7 +117,7 @@ jobs:
       if: steps.check.outputs.skip != 'true'
       shell: pwsh
       run: |
-        $assets = gh api --paginate repos/${{ github.repository }}/releases/tags/Nightly-Build --jq '.assets[].id' 2>$null
+        $assets = gh api --paginate repos/${{ github.repository }}/releases/tags/${{ steps.version.outputs.tag }} --jq '.assets[].id' 2>$null
         if ($LASTEXITCODE -ne 0 -or -not $assets) {
           Write-Host 'No existing nightly assets to clean.'
           return

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
         } else {
             $version = "0.0.0"
         }
-        $date = Get-Date -Format "yyyyMMdd"
+        $date = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcTime, 'China Standard Time').ToString('yyyyMMdd')
         $tag = "Nightly-Build"
         $title = "v$version-nightlybuild+$date"
         $shortSha = "${{ github.sha }}".Substring(0, 7)
@@ -112,6 +112,18 @@ jobs:
       run: |
         git tag -f ${{ steps.version.outputs.tag }}
         git push -f origin ${{ steps.version.outputs.tag }}
+
+    - name: Clean old nightly assets
+      if: steps.check.outputs.skip != 'true'
+      shell: pwsh
+      run: |
+        $assets = gh api repos/${{ github.repository }}/releases/tags/Nightly-Build --jq '.assets[].id' 2>$null
+        foreach ($id in $assets) {
+          gh api repos/${{ github.repository }}/releases/assets/$id -X DELETE
+          Write-Host "Deleted asset $id"
+        }
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish to GitHub Releases
       if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
         } else {
             $version = "0.0.0"
         }
-        $date = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcTime, 'China Standard Time').ToString('yyyyMMdd')
+        $date = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId([DateTime]::UtcNow, 'China Standard Time').ToString('yyyyMMdd')
         $tag = "Nightly-Build"
         $title = "v$version-nightlybuild+$date"
         $shortSha = "${{ github.sha }}".Substring(0, 7)
@@ -118,6 +118,10 @@ jobs:
       shell: pwsh
       run: |
         $assets = gh api --paginate repos/${{ github.repository }}/releases/tags/Nightly-Build --jq '.assets[].id' 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $assets) {
+          Write-Host 'No existing nightly assets to clean.'
+          return
+        }
         foreach ($id in $assets) {
           gh api repos/${{ github.repository }}/releases/assets/$id -X DELETE
           Write-Host "Deleted asset $id"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,7 +117,7 @@ jobs:
       if: steps.check.outputs.skip != 'true'
       shell: pwsh
       run: |
-        $assets = gh api repos/${{ github.repository }}/releases/tags/Nightly-Build --jq '.assets[].id' 2>$null
+        $assets = gh api --paginate repos/${{ github.repository }}/releases/tags/Nightly-Build --jq '.assets[].id' 2>$null
         foreach ($id in $assets) {
           gh api repos/${{ github.repository }}/releases/assets/$id -X DELETE
           Write-Host "Deleted asset $id"


### PR DESCRIPTION
## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

CI：
- 将夜间构建日期和标签的生成从使用服务器默认时区改为使用中国标准时间。
- 新增一个 CI 步骤，在上传新的夜间构建工件之前，先删除 Nightly-Build 发布中的现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

</details>

CI：
- 将夜间构建的日期/标签生成改为使用中国标准时间，而不是默认的服务器时区。
- 添加一个 CI 步骤，在上传新的夜间构建制品之前，从 Nightly-Build 发布中删除现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

CI：
- 将夜间构建日期和标签的生成从使用服务器默认时区改为使用中国标准时间。
- 新增一个 CI 步骤，在上传新的夜间构建工件之前，先删除 Nightly-Build 发布中的现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

</details>

</details>

CI：
- 将夜间构建标签日期更新为使用中国标准时间计算，而不是使用默认的服务器时区。
- 添加一个 CI 步骤，在上传新的夜间构建制品之前，删除 `Nightly-Build` 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

CI：
- 将夜间构建日期和标签的生成从使用服务器默认时区改为使用中国标准时间。
- 新增一个 CI 步骤，在上传新的夜间构建工件之前，先删除 Nightly-Build 发布中的现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

</details>

CI：
- 将夜间构建的日期/标签生成改为使用中国标准时间，而不是默认的服务器时区。
- 添加一个 CI 步骤，在上传新的夜间构建制品之前，从 Nightly-Build 发布中删除现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

CI：
- 将夜间构建日期和标签的生成从使用服务器默认时区改为使用中国标准时间。
- 新增一个 CI 步骤，在上传新的夜间构建工件之前，先删除 Nightly-Build 发布中的现有资产。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整夜间 CI 工作流，以使用中国标准时间生成夜间构建元数据，并在上传新资源前清理已有的发布资源。

CI：
- 将夜间构建的日期/标签生成逻辑从默认服务器时区改为使用中国标准时间。
- 新增一个 CI 步骤，在发布新的夜间构建制品之前，先删除 Nightly-Build 发布中的现有资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust nightly CI workflow to use China Standard Time for nightly build metadata and to clean existing release assets before uploading new ones.

CI:
- Update nightly build date/tag generation to use China Standard Time instead of the default server timezone.
- Add a CI step that removes existing assets from the Nightly-Build release before publishing new nightly artifacts.

</details>

</details>

</details>

</details>