### PR TITLE
refactor(logging): 日志系统改为 Minecraft 风格格式，logger 命名改用 __name__

### DIFF
--- a/src/danmaku_sender/controller/account_controller.py
+++ b/src/danmaku_sender/controller/account_controller.py
@@ -13,7 +13,7 @@ from danmaku_sender.runtime.managers.account_manager import AccountManager
 from danmaku_sender.service.auth_service import AuthService
 
 
-logger = logging.getLogger("App.Controller.Account")
+logger = logging.getLogger(__name__)
 
 
 class AccountController(QObject):

--- a/src/danmaku_sender/controller/auth_controller.py
+++ b/src/danmaku_sender/controller/auth_controller.py
@@ -10,7 +10,7 @@ from danmaku_sender.types.models.user import UserProfile
 from danmaku_sender.service.auth_service import AuthService
 
 
-logger = logging.getLogger("App.Controller.Auth")
+logger = logging.getLogger(__name__)
 
 
 class AuthController(QObject):
@@ -92,7 +92,7 @@ class QRLoginWorker(WorkerThread):
         super().__init__(parent)
         self.use_system_proxy = use_system_proxy
         self.stop_event = stop_event  # Controller 传入
-        self.logger = logging.getLogger("App.Controller.Auth.QRWorker")
+        self.logger = logging.getLogger(__name__)
 
     def run(self):
         try:

--- a/src/danmaku_sender/controller/concurrency.py
+++ b/src/danmaku_sender/controller/concurrency.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from PySide6.QtCore import QThread, QObject, Signal, QRunnable, Slot, QThreadPool
 
 
-logger = logging.getLogger("App.Controller.Concurrency")
+logger = logging.getLogger(__name__)
 
 
 class WorkerThread(QThread):
@@ -19,9 +19,19 @@ class WorkerThread(QThread):
     _keep_alive_registry = set()       # 静态注册表: 存放所有正在运行的任务，以防止被 GC
     _registry_lock = threading.Lock()  # 注册表线程锁
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if 'run' in cls.__dict__:
+            cls._original_run = cls.run
+            cls.run = cls._named_run
+
+    def _named_run(self):
+        threading.current_thread().name = type(self).__name__
+        self._original_run()
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.logger = logging.getLogger("App.Controller.Worker")
+        self.logger = logging.getLogger(__name__)
         self.finished.connect(self._unregister)  # 线程彻底结束时，将自己从保活注册表中移除
 
     def start(self, *args, **kwargs):
@@ -78,6 +88,7 @@ class PoolTask(QRunnable):
 
     def run(self):
         """重写 QRunnable.run(): 线程池调度入口"""
+        threading.current_thread().name = "PoolThread"
         try:
             # 执行传入的业务函数
             result = self.fn(*self.args, **self.kwargs)

--- a/src/danmaku_sender/controller/editor_controller.py
+++ b/src/danmaku_sender/controller/editor_controller.py
@@ -22,7 +22,7 @@ class EditorController(QObject):
 
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
-        self.logger = logging.getLogger("App.Controller.Editor")
+        self.logger = logging.getLogger(__name__)
         self.state = state
         self.session = EditorSession()
 

--- a/src/danmaku_sender/controller/history_controller.py
+++ b/src/danmaku_sender/controller/history_controller.py
@@ -7,7 +7,7 @@ from .concurrency import PoolTask
 from danmaku_sender.repo.history_manager import HistoryManager
 
 
-logger = logging.getLogger("App.Controller.History")
+logger = logging.getLogger(__name__)
 
 
 class HistoryController(QObject):

--- a/src/danmaku_sender/controller/monitor_controller.py
+++ b/src/danmaku_sender/controller/monitor_controller.py
@@ -12,7 +12,7 @@ from danmaku_sender.config import ApiAuthConfig, MonitorConfig
 from danmaku_sender.service.bili_monitor import BiliDanmakuMonitor
 
 
-logger = logging.getLogger("App.Controller.Monitor")
+logger = logging.getLogger(__name__)
 
 
 class MonitorController(QObject):
@@ -94,7 +94,7 @@ class MonitorTaskWorker(WorkerThread):
         parent=None
     ):
         super().__init__(parent)
-        self.logger = logging.getLogger("App.Controller.Monitor.Worker")
+        self.logger = logging.getLogger(__name__)
         self.target = target
         self.auth_config = auth_config
         self.monitor_config = monitor_config

--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -18,7 +18,7 @@ from danmaku_sender.config import ApiAuthConfig, SenderConfig
 from danmaku_sender.runtime.state.app_state import AppState
 
 
-logger = logging.getLogger("App.Controller.Sender")
+logger = logging.getLogger(__name__)
 
 
 class SenderStatus(Enum):

--- a/src/danmaku_sender/controller/system_controller.py
+++ b/src/danmaku_sender/controller/system_controller.py
@@ -7,7 +7,7 @@ from danmaku_sender.repo.github_client import UpdateChecker, UpdateInfo
 from danmaku_sender.config.app_meta import AppInfo
 
 
-logger = logging.getLogger("App.Controller.Update")
+logger = logging.getLogger(__name__)
 
 
 def _check_update(use_proxy: bool):

--- a/src/danmaku_sender/controller/system_utils.py
+++ b/src/danmaku_sender/controller/system_utils.py
@@ -4,7 +4,7 @@ import platform
 import threading
 
 
-logger = logging.getLogger("App.Controller.Utils")
+logger = logging.getLogger(__name__)
 
 
 IS_WINDOWS = platform.system() == "Windows"

--- a/src/danmaku_sender/controller/video_controller.py
+++ b/src/danmaku_sender/controller/video_controller.py
@@ -8,7 +8,7 @@ from danmaku_sender.service.video_fetcher import VideoFetcher
 from .concurrency import PoolTask
 
 
-logger = logging.getLogger("App.Controller.Video")
+logger = logging.getLogger(__name__)
 
 
 # 使用独立单线程后台线程池处理批量获取任务，避免过度并发。

--- a/src/danmaku_sender/repo/bili_api_client.py
+++ b/src/danmaku_sender/repo/bili_api_client.py
@@ -30,7 +30,7 @@ class BiliApiClient:
         self.sessdata = sessdata
         self.bili_jct = bili_jct
         self.use_system_proxy = use_system_proxy
-        self.logger = logger if logger else logging.getLogger("App.System.API")
+        self.logger = logger if logger else logging.getLogger(__name__)
         self.session = self._create_session()
 
         try:

--- a/src/danmaku_sender/repo/github_client.py
+++ b/src/danmaku_sender/repo/github_client.py
@@ -5,7 +5,7 @@ from packaging import version
 from ..config.app_meta import Links
 
 
-logger = logging.getLogger("App.System.Updater")
+logger = logging.getLogger(__name__)
 
 
 class UpdateInfo:

--- a/src/danmaku_sender/repo/history_manager.py
+++ b/src/danmaku_sender/repo/history_manager.py
@@ -11,7 +11,7 @@ from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import DanmakuStatus, VideoTarget
 
 
-logger = logging.getLogger("App.System.DB")
+logger = logging.getLogger(__name__)
 
 
 class HistoryManager:

--- a/src/danmaku_sender/repo/wbi_signer.py
+++ b/src/danmaku_sender/repo/wbi_signer.py
@@ -8,7 +8,7 @@ from hashlib import md5
 import requests
 
 
-logger = logging.getLogger("App.System.Signer")
+logger = logging.getLogger(__name__)
 
 
 class WbiSigner:

--- a/src/danmaku_sender/runtime/infra/log_utils.py
+++ b/src/danmaku_sender/runtime/infra/log_utils.py
@@ -10,10 +10,9 @@ from danmaku_sender.config.app_meta import AppInfo
 
 
 class LogNamespace:
-    """日志命名空间契约"""
-    SENDER = "App.Sender"
-    MONITOR = "App.Monitor"
-    SYSTEM = "App.System"
+    """日志命名空间契约（基于模块路径）"""
+    SENDER_PREFIXES = ("danmaku_sender.service.sender", "danmaku_sender.ui.sender")
+    MONITOR_PREFIXES = ("danmaku_sender.service.bili_monitor", "danmaku_sender.ui.monitor_page", "danmaku_sender.controller.monitor_controller")
 
 
 class GuiLoggingHandler(logging.Handler):
@@ -57,22 +56,21 @@ class GuiLoggingHandler(logging.Handler):
         """
         发出一条日志记录。
 
-        该方法会处理日志记录，并根据日志器名称前缀，将其路由至对应的信号。
-        它针对不同组件的日志做分流处理:
-        来自 "App.Sender" 的日志，发送至 sender_signal
-        来自 "App.Monitor" 的日志，发送至 monitor_signal
-        来自 "App.System" 及其他来源的日志，将被忽略
+        该方法会处理日志记录，并根据模块路径前缀路由至对应的信号:
+        danmaku_sender.service.sender / danmaku_sender.ui.sender → sender_signal
+        danmaku_sender.service.bili_monitor / danmaku_sender.ui.monitor_page → monitor_signal
+        其他模块的日志将被忽略
 
         Args:
             record (logging.LogRecord)：待输出的日志记录对象。
         """
         try:
             text = self.format(record)
-            if record.name.startswith(LogNamespace.SENDER) and self._sender_signal:
+            if record.name.startswith(LogNamespace.SENDER_PREFIXES) and self._sender_signal:
                 self._sender_signal.emit(text)
-            elif record.name.startswith(LogNamespace.MONITOR) and self._monitor_signal:
+            elif record.name.startswith(LogNamespace.MONITOR_PREFIXES) and self._monitor_signal:
                 self._monitor_signal.emit(text)
-            # App.System 或其他开头的日志直接忽略
+            # 其他模块的日志直接忽略
         except Exception:
             self.handleError(record)
 
@@ -97,13 +95,13 @@ def init_app_logging(log_dir: Path):
     log_file_path = log_dir / AppInfo.LOG_FILE_NAME
 
     # --- 定义格式 ---
-    # 文件和控制台: 详细格式
+    # 文件和控制台: 详细格式 [时间] [线程/级别] [模块名]: 消息
     detailed_formatter = logging.Formatter(
-        '%(asctime)s [%(name)s] %(levelname)s - %(message)s',
+        '[%(asctime)s] [%(threadName)s/%(levelname)s] [%(name)s]: %(message)s',
         datefmt='%H:%M:%S'
     )
-    # GUI: 精简格式
-    gui_formatter = logging.Formatter('%(asctime)s %(message)s', datefmt='%H:%M:%S')
+    # GUI: 精简格式 [时间] [级别] 消息
+    gui_formatter = logging.Formatter('[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%H:%M:%S')
 
     # --- 获取根 Logger 并重置环境 ---
     root_logger = logging.getLogger()

--- a/src/danmaku_sender/runtime/infra/resources.py
+++ b/src/danmaku_sender/runtime/infra/resources.py
@@ -11,5 +11,5 @@ class AppResources:
     """
 
     def __init__(self) -> None:
-        self.logger: logging.Logger = logging.getLogger("App")
+        self.logger: logging.Logger = logging.getLogger(__name__)
         self.theme: ThemeManager = ThemeManager.instance()

--- a/src/danmaku_sender/runtime/managers/account_manager.py
+++ b/src/danmaku_sender/runtime/managers/account_manager.py
@@ -15,7 +15,7 @@ KEYRING_SERVICE_NAME = f"{AppInfo.NAME_EN}-CredentialsKey"
 KEYRING_USERNAME = "default_user"
 ACCOUNTS_PATH = AppInfo.Paths.ACCOUNTS
 
-logger = logging.getLogger("App.System.Auth")
+logger = logging.getLogger(__name__)
 
 
 class AccountManager:

--- a/src/danmaku_sender/runtime/managers/config_manager.py
+++ b/src/danmaku_sender/runtime/managers/config_manager.py
@@ -9,7 +9,7 @@ from danmaku_sender.config.app_meta import AppInfo
 from danmaku_sender.config import SenderConfig, MonitorConfig, ValidationConfig
 
 
-logger = logging.getLogger("App.System.Config")
+logger = logging.getLogger(__name__)
 
 CONFIG_PATH = AppInfo.Paths.CONFIG
 

--- a/src/danmaku_sender/runtime/managers/theme_manager.py
+++ b/src/danmaku_sender/runtime/managers/theme_manager.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QGuiApplication
 from PySide6.QtCore import Qt, QObject, Signal, Slot
 
 
-logger = logging.getLogger("App.System.Theme")
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/src/danmaku_sender/runtime/runtime.py
+++ b/src/danmaku_sender/runtime/runtime.py
@@ -9,7 +9,7 @@ from danmaku_sender.config.app_meta import AppInfo
 from danmaku_sender.repo.history_manager import HistoryManager
 
 
-logger = logging.getLogger("App.Runtime")
+logger = logging.getLogger(__name__)
 
 
 class Runtime:

--- a/src/danmaku_sender/service/auth_service.py
+++ b/src/danmaku_sender/service/auth_service.py
@@ -13,7 +13,7 @@ from danmaku_sender.types.models.user import UserProfile
 from danmaku_sender.config import ApiAuthConfig
 
 
-logger = logging.getLogger("App.Service.Auth")
+logger = logging.getLogger(__name__)
 
 
 class AuthService:

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -25,7 +25,7 @@ class BiliDanmakuMonitor:
 
         self.danmaku_parser = DanmakuParser()
         self.history_manager = history_manager
-        self.logger = logging.getLogger("App.Monitor.Engine")
+        self.logger = logging.getLogger(__name__)
 
     @staticmethod
     @contextmanager

--- a/src/danmaku_sender/service/danmaku_exporter.py
+++ b/src/danmaku_sender/service/danmaku_exporter.py
@@ -6,7 +6,7 @@ from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import UnsentDanmakusRecord
 
 
-logger = logging.getLogger("App.System.Exporter")
+logger = logging.getLogger(__name__)
 
 
 def create_xml_from_danmakus(danmakus: list[UnsentDanmakusRecord], filepath: str) -> None:

--- a/src/danmaku_sender/service/danmaku_parser.py
+++ b/src/danmaku_sender/service/danmaku_parser.py
@@ -11,7 +11,7 @@ class DanmakuParser:
     用于解析Bilibili XML格式的弹幕数据，支持本地文件和在线内容的解析。
     """
     def __init__(self):
-        self.logger = logging.getLogger("App.System.Parser")
+        self.logger = logging.getLogger(__name__)
 
     def parse_xml_file(self, xml_path: str) -> list[Danmaku]:
         """

--- a/src/danmaku_sender/service/editor_session.py
+++ b/src/danmaku_sender/service/editor_session.py
@@ -15,7 +15,7 @@ class EditorSession:
     只负责暂存区的增删改查与撤销树维护，不主动干涉全局状态 (AppState)。
     """
     def __init__(self) -> None:
-        self.logger = logging.getLogger("App.System.Editor.Session")
+        self.logger = logging.getLogger(__name__)
         self.items: dict[str, EditorItem] = {}          # 核心存储：UUID 映射表
         self.item_order: list[str] = []                 # 顺序表：维护弹幕在视频中的物理播放顺序
         self.undo_stack: list[list[AtomicChange]] = []  # 操作栈：撤销功能

--- a/src/danmaku_sender/service/sender/delay_manager.py
+++ b/src/danmaku_sender/service/sender/delay_manager.py
@@ -27,7 +27,7 @@ class DelayManager:
             rest_min (float): 休息时间的随机下界（秒）
             rest_max (float): 休息时间的随机上界（秒）
         """
-        self.logger = logging.getLogger("App.Sender.Delay")
+        self.logger = logging.getLogger(__name__)
 
         # 基础随机延迟配置
         self.normal_min = normal_min

--- a/src/danmaku_sender/service/sender/executor.py
+++ b/src/danmaku_sender/service/sender/executor.py
@@ -18,7 +18,7 @@ class DanmakuExecutor:
     """
     def __init__(self, api_client: BiliApiClient):
         self.api_client = api_client
-        self.logger = logging.getLogger("App.Sender.Executor")
+        self.logger = logging.getLogger(__name__)
 
     def execute(self, target: VideoTarget, danmaku: Danmaku, stop_event: Event) -> DanmakuSendResult:
         """

--- a/src/danmaku_sender/service/sender/pipeline.py
+++ b/src/danmaku_sender/service/sender/pipeline.py
@@ -22,7 +22,7 @@ from danmaku_sender.types.models.common import VideoTarget
 from danmaku_sender.config import ApiAuthConfig, SenderConfig
 
 
-logger = logging.getLogger("App.Sender.Pipeline")
+logger = logging.getLogger(__name__)
 
 
 class SendPipeline:

--- a/src/danmaku_sender/service/sender/scheduler.py
+++ b/src/danmaku_sender/service/sender/scheduler.py
@@ -18,7 +18,7 @@ class DanmakuScheduler:
     职责：遍历队列、断点续传（去重）、容错处理、时间控制与任务阻断。
     """
     def __init__(self, executor: DanmakuExecutor, history_manager: HistoryManager | None = None):
-        self.logger = logging.getLogger("App.Sender.Scheduler")
+        self.logger = logging.getLogger(__name__)
         self.executor = executor
         self.history_manager = history_manager
 

--- a/src/danmaku_sender/service/video_fetcher.py
+++ b/src/danmaku_sender/service/video_fetcher.py
@@ -12,7 +12,7 @@ class VideoFetcher:
     """
     def __init__(self, api_client: BiliApiClient, logger: logging.Logger | None = None):
         self.client = api_client
-        self.logger = logger if logger else logging.getLogger("App.System.Fetcher")
+        self.logger = logger if logger else logging.getLogger(__name__)
 
     @classmethod
     def fetch_info_from_config(cls, bvid: str, auth_config: ApiAuthConfig) -> VideoInfo:

--- a/src/danmaku_sender/ui/account_manager/page.py
+++ b/src/danmaku_sender/ui/account_manager/page.py
@@ -16,7 +16,7 @@ from danmaku_sender.runtime.state.app_state import AppState
 from danmaku_sender.controller.account_controller import AccountController
 from danmaku_sender.ui.framework.style_loader import SvgIcon
 
-logger = logging.getLogger("App.System.Account")
+logger = logging.getLogger(__name__)
 
 
 class AccountDialog(QDialog):

--- a/src/danmaku_sender/ui/common/notification.py
+++ b/src/danmaku_sender/ui/common/notification.py
@@ -6,7 +6,7 @@ from danmaku_sender.config.app_meta import AppInfo
 from danmaku_sender.config.app_meta import AppInfo
 
 
-logger = logging.getLogger("App.System.Notify")
+logger = logging.getLogger(__name__)
 
 
 ICON_PATH = AppInfo.Paths.ASSETS / 'icon.ico'
@@ -46,6 +46,7 @@ def send_windows_notification(title: str, message: str):
     notification_thread = threading.Thread(
         target=_send_notification_wrapper,
         args=(title, message),
+        name="Notification",
         daemon=True
     )
     notification_thread.start()

--- a/src/danmaku_sender/ui/dialogs.py
+++ b/src/danmaku_sender/ui/dialogs.py
@@ -18,7 +18,7 @@ from ..config.app_meta import AppInfo, Links
 from danmaku_sender.config.app_meta import AppInfo
 
 
-logger = logging.getLogger("App.System.UI.Dialog")
+logger = logging.getLogger(__name__)
 
 
 class MarkdownBrowser(QTextBrowser):

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -22,7 +22,7 @@ class EditorPage(QWidget):
     def __init__(self, state: AppState):
         super().__init__()
         self.controller = EditorController(state, self)
-        self.logger = logging.getLogger("App.System.UI.Editor")
+        self.logger = logging.getLogger(__name__)
 
         self.current_item_id: str | None = None
 

--- a/src/danmaku_sender/ui/framework/binder.py
+++ b/src/danmaku_sender/ui/framework/binder.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
     QLineEdit, QComboBox
 )
 
-logger = logging.getLogger("App.System.Framework.Binder")
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable

--- a/src/danmaku_sender/ui/framework/image_processor.py
+++ b/src/danmaku_sender/ui/framework/image_processor.py
@@ -5,7 +5,7 @@ from PySide6.QtGui import QPixmap, QImage, QPainter, QPainterPath
 from PySide6.QtSvg import QSvgRenderer
 
 
-logger = logging.getLogger("App.System.ImageProcessor")
+logger = logging.getLogger(__name__)
 
 
 class QtImageProcessor:

--- a/src/danmaku_sender/ui/framework/style_loader.py
+++ b/src/danmaku_sender/ui/framework/style_loader.py
@@ -10,7 +10,7 @@ from danmaku_sender.config.app_meta import AppInfo
 from danmaku_sender.runtime.managers.theme_manager import ThemeManager
 
 
-logger = logging.getLogger("App.UI.StyleLoader")
+logger = logging.getLogger(__name__)
 
 
 def get_app_icon() -> QIcon:

--- a/src/danmaku_sender/ui/history/page.py
+++ b/src/danmaku_sender/ui/history/page.py
@@ -18,7 +18,7 @@ from danmaku_sender.controller.video_controller import VideoController
 from danmaku_sender.controller.history_controller import HistoryController
 
 
-logger = logging.getLogger("App.System.UI.History")
+logger = logging.getLogger(__name__)
 
 
 class HistoryPage(QWidget):

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -43,7 +43,7 @@ class MainWindow(QMainWindow):
         # 控制器
         self.auth_controller = AuthController(self)
         self.system_controller = SystemController(self)
-        self.logger = logging.getLogger("App.System.UI.Main")
+        self.logger = logging.getLogger(__name__)
         self._log_signals_connected = False
         self._help_dialog = None  # 存储帮助窗口的引用，防止被垃圾回收
         self._current_profile: UserProfile | None = None

--- a/src/danmaku_sender/ui/monitor_page.py
+++ b/src/danmaku_sender/ui/monitor_page.py
@@ -25,7 +25,7 @@ class MonitorPage(QWidget):
     def __init__(self, state: AppState, history_manager: HistoryManager):
         super().__init__()
         self.state = state
-        self.logger = logging.getLogger("App.Monitor.UI")
+        self.logger = logging.getLogger(__name__)
 
         self.monitor_controller = MonitorController(history_manager, self)
 

--- a/src/danmaku_sender/ui/sender/data_binding.py
+++ b/src/danmaku_sender/ui/sender/data_binding.py
@@ -11,7 +11,7 @@ from danmaku_sender.runtime.state.app_state import AppState
 from danmaku_sender.utils.string_utils import parse_bilibili_link
 
 
-logger = logging.getLogger("App.Sender.DataBinding")
+logger = logging.getLogger(__name__)
 
 
 class SenderDataBinding(QObject):

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -28,7 +28,7 @@ class SenderPage(QWidget):
     def __init__(self, state: AppState, history_manager: HistoryManager):
         super().__init__()
         self.state = state
-        self.logger = logging.getLogger("App.Sender.UI")
+        self.logger = logging.getLogger(__name__)
         self.video_controller = VideoController(self)
         self.sender_controller = SenderController(state, history_manager, self)
         self.binding = SenderDataBinding(state, self.sender_controller, self.video_controller, self)


### PR DESCRIPTION
- 格式从 '%(asctime)s [%(name)s] %(levelname)s - %(message)s' 改为 '[%(asctime)s] [%(threadName)s/%(levelname)s] [%(name)s]: %(message)s'
- 全部 40 处 logging.getLogger('App.xxx') 改为 logging.getLogger(__name__) 日志名称跟随模块路径，重构时自动更新
- GuiLoggingHandler 路由前缀适配新的模块路径
- WorkerThread 子类通过 __init_subclass__ 自动命名线程
- PoolTask 线程命名为 PoolThread
- Notification 线程命名为 Notification
- 修复监视器日志未路由到监视面板的问题

## Summary by Sourcery

重构日志系统，引入模块化命名和支持线程信息的日志格式，并提升后台任务及监控日志的可观测性。

Bug Fixes:
- 修复监控日志无法正确路由到监控面板的问题。

Enhancements:
- 统一应用日志为 Minecraft 风格的格式，包含时间、线程、级别和模块名。
- 将日志记录器名称统一为基于模块路径的 `__name__`，以提升日志来源的可追踪性并简化代码重构。
- 为工作线程、线程池任务和系统通知设置明确的线程名称，以增强日志上下文信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构日志系统以采用模块化命名和线程感知格式，并改进后台任务与监视器日志的可观测性。

Bug Fixes:
- 修复监视器日志无法正确路由到监视面板的问题。

Enhancements:
- 将应用日志统一为 Minecraft 风格格式，包含时间、线程、级别和模块名。
- 将日志器命名统一为基于模块路径的 __name__，提升日志来源可追踪性并简化代码重构。
- 为工作线程、线程池任务和系统通知设置明确的线程名称，以增强日志上下文。

</details>