### PR TITLE
fix(ci): 修复 Inno Setup 简体中文语言包下载 URL 404

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Build Inno Setup Installer
       shell: pwsh
       run: |
-        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl" -OutFile "ChineseSimplified.isl"
+        Invoke-WebRequest -Uri "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/ChineseSimplified.isl" -OutFile "ChineseSimplified.isl"
 
         if (!(Test-Path "Output")) { New-Item -ItemType Directory -Path "Output" }
 


### PR DESCRIPTION
jrsoftware/issrc 仓库将 ChineseSimplified.isl 从 Unofficial/ 目录 移至 Languages/ 根目录，更新 CI 工作流中的下载地址。

## Summary by Sourcery

更新 CI 中 Inno Setup 简体中文语言包的下载地址，确保安装程序构建能够正常完成。

Bug Fixes:
- 修复 CI 构建流程因 Inno Setup 简体中文语言包下载地址变更导致的 404 错误。

CI:
- 更新 Inno Setup 简体中文语言包的 CI 下载地址以匹配其在上游仓库中的新位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 CI 中 Inno Setup 简体中文语言包的下载地址，确保安装程序构建能够正常完成。

Bug Fixes:
- 修复 CI 构建流程因 Inno Setup 简体中文语言包下载地址变更导致的 404 错误。

CI:
- 更新 Inno Setup 简体中文语言包的 CI 下载地址以匹配其在上游仓库中的新位置。

</details>