### PR TITLE
feat(queue): Stage 3.4 — 发送策略迁移至设置页与底部操作区重构

### DIFF
--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -157,6 +157,7 @@ class SenderController(QObject):
         self._queue_worker = QueueWorker(
             queue_state=queue_state,
             auth_config=auth_config,
+            sender_config=self.state.sender_config,
             history_manager=self.history_manager,
             stop_event=self._stop_event,
         )
@@ -308,6 +309,7 @@ class QueueWorker(WorkerThread):
         self,
         queue_state: QueueState,
         auth_config: ApiAuthConfig,
+        sender_config: SenderConfig,
         history_manager: HistoryManager,
         stop_event: threading.Event,
         parent=None,
@@ -315,6 +317,7 @@ class QueueWorker(WorkerThread):
         super().__init__(parent)
         self.queue_state = queue_state
         self.auth_config = auth_config
+        self.sender_config = sender_config
         self.history_manager = history_manager
         self.stop_event = stop_event
 
@@ -377,10 +380,12 @@ class QueueWorker(WorkerThread):
 
         try:
             pipeline = SendPipeline(self.auth_config, self.history_manager)
+            config = task.config_snapshot.model_copy()
+            config.skip_sent = self.sender_config.skip_sent  # 全局策略，不走快照
             job = SendJob(
                 target=task.target,
                 danmakus=task.danmakus,
-                config=task.config_snapshot,
+                config=config,
                 stop_event=self.stop_event,
             )
             ctx = pipeline.execute(job, progress_emitter=progress_emitter)

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -193,9 +193,9 @@ class MainWindow(QMainWindow):
         self._sc_open = QShortcut(QKeySequence.StandardKey.Open, self)
         self._sc_open.activated.connect(self.page_sender._select_file)
 
-        # Ctrl+Enter: 开始发送
+        # Ctrl+Enter: 启动队列
         self._sc_send = QShortcut(QKeySequence(Qt.Key.Key_Return | Qt.KeyboardModifier.ControlModifier), self)
-        self._sc_send.activated.connect(self.page_sender._toggle_task)
+        self._sc_send.activated.connect(self.page_sender._start_queue)
 
         # Ctrl+,: 打开全局设置
         self._sc_settings = QShortcut(QKeySequence(Qt.Key.Key_Comma | Qt.KeyboardModifier.ControlModifier), self)

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -1,22 +1,22 @@
 import logging
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel, QDialog,
-    QGroupBox, QTextEdit, QProgressBar, QFileDialog, QMessageBox,
+    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
+    QGroupBox, QTextEdit, QProgressBar, QMessageBox,
     QTableView, QHeaderView, QAbstractItemView, QMenu
 )
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent, QShortcut, QKeySequence
 from PySide6.QtCore import Qt, QPoint, QModelIndex, QDateTime, Signal, Slot
 
-from .components import StrategySettingsTabs, BasicParamsGroup, PreSendDialog, QueueTableModel
+from .components import BasicParamsGroup, QueueTableModel
 from .components.queue_table import ProgressBarDelegate
 from .data_binding import SenderDataBinding
 
 from danmaku_sender.ui.framework.style_loader import SvgIcon
 from danmaku_sender.controller.video_controller import VideoController
-from danmaku_sender.controller.sender_controller import SenderController, SenderStatus, SenderState
+from danmaku_sender.controller.sender_controller import SenderController, SenderStatus
 from danmaku_sender.types.models.video import VideoInfo
-from danmaku_sender.types.models.common import VideoTarget, UnsentDanmakusRecord
+from danmaku_sender.types.models.common import VideoTarget
 from danmaku_sender.types.models.queue import QueueTask, TaskStatus
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.service.sender import SendingContext
@@ -55,12 +55,9 @@ class SenderPage(QWidget):
         main_layout.setSpacing(10)
         main_layout.setContentsMargins(10, 10, 10, 10)
 
-        # --- 基础参数策略区 ---
+        # --- 基础参数区 ---
         self.basic_group = BasicParamsGroup(self.state)
-        self.strategy_tabs = StrategySettingsTabs(self.state)
-
         main_layout.addWidget(self.basic_group)
-        main_layout.addWidget(self.strategy_tabs)
 
         # --- 队列区 ---
         queue_group = QGroupBox("发送队列")
@@ -112,22 +109,11 @@ class SenderPage(QWidget):
         self._btn_add_to_queue.setProperty("action", "true")
         self._btn_add_to_queue.setProperty("state", "ready")
 
-        self._btn_start_queue = QPushButton("启动队列")
-        self._btn_start_queue.setFixedWidth(100)
-        self._btn_start_queue.setCursor(Qt.CursorShape.PointingHandCursor)
-
-        self._btn_stop_queue = QPushButton("停止队列")
-        self._btn_stop_queue.setFixedWidth(100)
-        self._btn_stop_queue.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._btn_stop_queue.setEnabled(False)
-
         self._btn_clear_completed = QPushButton("清除已完成")
         self._btn_clear_completed.setFixedWidth(100)
         self._btn_clear_completed.setCursor(Qt.CursorShape.PointingHandCursor)
 
         queue_btn_layout.addWidget(self._btn_add_to_queue)
-        queue_btn_layout.addWidget(self._btn_start_queue)
-        queue_btn_layout.addWidget(self._btn_stop_queue)
         queue_btn_layout.addWidget(self._btn_clear_completed)
         queue_btn_layout.addStretch()
 
@@ -146,24 +132,30 @@ class SenderPage(QWidget):
         # --- 操作区 ---
         action_layout = QHBoxLayout()
 
-        # 状态
         self.status_label = QLabel("发送器：待命")
 
-        # 进度条
         self.progress_bar = QProgressBar()
         self.progress_bar.setValue(0)
 
-        # 按钮
-        self.start_btn = QPushButton("开始发送")
-        self.start_btn.setIcon(SvgIcon("start.svg"))
-        self.start_btn.setFixedWidth(100)
-        self.start_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.start_btn.setProperty("action", "true")
-        self.start_btn.setProperty("state", "ready")
+        self._btn_start_queue = QPushButton("启动队列")
+        self._btn_start_queue.setIcon(SvgIcon("start.svg"))
+        self._btn_start_queue.setFixedWidth(100)
+        self._btn_start_queue.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._btn_start_queue.setProperty("action", "true")
+        self._btn_start_queue.setProperty("state", "ready")
+
+        self._btn_stop_queue = QPushButton("停止队列")
+        self._btn_stop_queue.setIcon(SvgIcon("stop.svg"))
+        self._btn_stop_queue.setFixedWidth(100)
+        self._btn_stop_queue.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._btn_stop_queue.setProperty("action", "true")
+        self._btn_stop_queue.setProperty("state", "running")
+        self._btn_stop_queue.setVisible(False)
 
         action_layout.addWidget(self.status_label)
         action_layout.addWidget(self.progress_bar, stretch=1)
-        action_layout.addWidget(self.start_btn)
+        action_layout.addWidget(self._btn_start_queue)
+        action_layout.addWidget(self._btn_stop_queue)
 
         main_layout.addLayout(action_layout)
 
@@ -198,8 +190,11 @@ class SenderPage(QWidget):
         self.basic_group.fetch_btn.clicked.connect(self._fetch_video_info)
         self.basic_group.part_combo.currentIndexChanged.connect(self._on_part_selected)
 
-        # 本地信号
-        self.start_btn.clicked.connect(self._toggle_task)
+        # 队列按钮
+        self._btn_add_to_queue.clicked.connect(self._add_to_queue)
+        self._btn_clear_completed.clicked.connect(self._clear_completed)
+        self._btn_start_queue.clicked.connect(self._start_queue)
+        self._btn_stop_queue.clicked.connect(self._stop_queue)
 
         # DataBinding
         self.binding.fileLoaded.connect(self._on_file_loaded)
@@ -207,11 +202,6 @@ class SenderPage(QWidget):
         self.binding.videoFetchStarted.connect(self._on_fetch_started)
         self.binding.videoFetched.connect(self._on_fetch_succeeded)
         self.binding.videoFetchFailed.connect(self._on_fetch_failed)
-
-        # SenderController (单任务)
-        self.sender_controller.progressUpdated.connect(self._on_send_progress)
-        self.sender_controller.progressUpdated.connect(self.progressUpdated.emit)
-        self.sender_controller.taskFinished.connect(self._on_send_finished)
 
         # SenderController (队列)
         self.sender_controller.queueTaskStarted.connect(self._on_queue_task_started)
@@ -222,21 +212,13 @@ class SenderPage(QWidget):
         self.sender_controller.queueProgressUpdated.connect(self._on_queue_progress)
         self.sender_controller.taskProgressUpdated.connect(self._on_task_progress)
 
-
         # QueueState
         self.state.queue_state.tasksChanged.connect(self._on_queue_changed)
         self.state.queue_state.taskStatusChanged.connect(self._on_queue_task_status_changed)
 
-        # 队列按钮
-        self._btn_add_to_queue.clicked.connect(self._add_to_queue)
-        self._btn_start_queue.clicked.connect(self._start_queue)
-        self._btn_stop_queue.clicked.connect(self._stop_queue)
-        self._btn_clear_completed.clicked.connect(self._clear_completed)
-
     def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
         self.basic_group.init_bindings()
-        self.strategy_tabs.init_bindings()
 
         # 监听共享数据变化（编辑器提交等场景）
         self.state.video_state.subscribe("loaded_danmakus", self._on_loaded_danmakus_changed)
@@ -300,49 +282,6 @@ class SenderPage(QWidget):
         data = self.basic_group.part_combo.itemData(index)
         part_name = self.basic_group.part_combo.currentText()
         self.binding.select_part(index, data, part_name)
-
-    @Slot()
-    def _toggle_task(self):
-        """开始/停止 任务"""
-        if self.sender_controller.is_queue_running():
-            return
-        # 如果正在运行 -> 停止
-        if self.sender_controller.is_running():
-            self.sender_controller.stop_task()
-            self._update_ui_for_state(SenderState.STOPPING)
-            self.logger.info("发送器：正在请求中止...")
-            return
-
-        # 如果未运行 -> 开始
-        # 校验
-        status = self.sender_controller.send_status
-        match status:
-            case SenderStatus.EDITOR_DIRTY:
-                QMessageBox.warning(self, "存在未保存的修改",
-                    "检测到【弹幕编辑器】中有未应用的修改！\n\n请先返回校验器点击“应用所有修改”，\n否则发送的将是旧的、未修复的弹幕。")
-                return
-            case SenderStatus.NOT_READY:
-                QMessageBox.warning(self, "条件不足", "请确保 BV号、分P、弹幕文件 均已就绪。")
-                return
-            case SenderStatus.NO_CREDENTIALS:
-                QMessageBox.warning(self, "凭证缺失", "请先在账号管理页登入账号或填入 SESSDATA 和 BILI_JCT。")
-                return
-
-        # 确认对话框
-        dialog = PreSendDialog(self.state, self)
-        if dialog.exec() != QDialog.DialogCode.Accepted:
-            return
-
-        # 锁定 UI
-        self._update_ui_for_state(SenderState.RUNNING)
-
-        state = self.state
-        target = VideoTarget(
-            bvid=state.video_state.bvid,
-            cid=state.video_state.selected_cid,
-            title=state.video_state.video_title
-        )
-        self.sender_controller.start_task(target, state.video_state.loaded_danmakus, state.get_api_auth(), state.sender_config)
 
     @Slot(QModelIndex)
     def _on_queue_double_clicked(self, index: QModelIndex):
@@ -531,45 +470,6 @@ class SenderPage(QWidget):
     # endregion
     # region Slots SenderController
 
-    @Slot(int, int, float)
-    def _on_send_progress(self, attempted: int, total: int, eta_sec: float):
-        if total > 0:
-            val = int((attempted / total) * 100)
-            self.progress_bar.setValue(val)
-
-            # ETA 计算逻辑
-            remaining = total - attempted
-            if remaining > 0:
-                duration = format_duration(eta_sec)
-                finish_time = QDateTime.currentDateTime().addSecs(int(eta_sec)).toString("HH:mm:ss")
-                display_text = f"%p% (剩余 {duration} | 预计 {finish_time} 结束)"
-                self.progress_bar.setFormat(display_text)
-                self.progress_bar.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            else:
-                self.progress_bar.setFormat("%p%")
-
-        self.status_label.setText(f"发送中: {attempted}/{total}")
-
-    @Slot(object)
-    def _on_send_finished(self, ctx: SendingContext):
-        """任务结束后的清理与保存逻辑"""
-        # 恢复 UI 状态
-        self._update_ui_for_state(SenderState.READY)
-
-        if ctx and ctx.is_manually_stopped:
-            self.status_label.setText("发送器：任务中止")
-            self.progress_bar.setFormat("%p% (已停止)")
-        else:
-            self.status_label.setText("发送器：任务结束")
-            self.progress_bar.setFormat("%p% (已完成)")
-
-        if ctx:
-            self._send_desktop_notification(ctx, ctx.is_manually_stopped)
-
-            # 如果有未发出的弹幕，引导保存
-            if ctx.unsent_records:
-                self._prompt_save_unsent_xml(ctx.unsent_records)
-
     # endregion
     # region Slots Queue
 
@@ -678,10 +578,13 @@ class SenderPage(QWidget):
 
     def _update_queue_ui(self, running: bool):
         self._btn_add_to_queue.setEnabled(not running)
-        self._btn_start_queue.setEnabled(not running)
-        self._btn_stop_queue.setEnabled(running)
         self._btn_clear_completed.setEnabled(not running)
         self._queue_model.queue_running = running
+
+        # 底部按钮切换
+        self._btn_start_queue.setVisible(not running)
+        self._btn_stop_queue.setVisible(running)
+
         if running:
             self._set_inputs_locked(True)
             self.log_output.clear()
@@ -694,101 +597,9 @@ class SenderPage(QWidget):
     # endregion
     # endregion
 
-    def _send_desktop_notification(self, ctx: SendingContext, is_stopped: bool):
-        """发送系统桌面通知"""
-        title = "弹幕发送任务已结束"
-        summary = f"成功: {ctx.success_count} / 尝试: {ctx.attempted_count} / 总计: {ctx.total}"
-
-        if ctx.auto_stop_reason:
-            msg = f"自动停止：{ctx.auto_stop_reason}\n{summary}"
-        elif is_stopped:
-            msg = f"任务已被手动停止。\n{summary}"
-        elif ctx.fatal_error_occurred:
-            msg = f"任务因致命错误中断！\n{summary}"
-        elif ctx.total == 0:
-            msg = "没有需要发送的弹幕。"
-        elif ctx.success_count == ctx.attempted_count:
-            msg = f"任务已完成！所有 {ctx.success_count} 条均发送成功。"
-        else:
-            msg = f"任务已完成。\n{summary}"
-
-        send_windows_notification(title, msg)
-
-    def _prompt_save_unsent_xml(self, unsent_danmakus: list[UnsentDanmakusRecord]):
-        """询问并保存失败的弹幕到 XML"""
-        count = len(unsent_danmakus)
-        reply = QMessageBox.question(
-            self, "保存失败弹幕",
-            f"有 {count} 条弹幕发送失败。\n是否保存为新的 XML 文件以便重新发送？",
-            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-        )
-        if reply == QMessageBox.StandardButton.Yes:
-            file_path, _ = QFileDialog.getSaveFileName(self, "保存XML", "unsent.xml", "XML Files (*.xml)")
-            if file_path:
-                self.logger.info(f"📥 正在保存未发送弹幕至: {file_path}")
-                self.sender_controller.export_unsent_xml(
-                    unsent_danmakus, file_path,
-                    on_success=lambda _: self._on_export_success(file_path),
-                    on_error=self._on_export_error,
-                )
-
-    @Slot(str)
-    def _on_export_success(self, file_path: str):
-        self.logger.info(f"✅ 未发送弹幕已保存至: {file_path}")
-        QMessageBox.information(self, "保存成功", f"文件已保存至：\n{file_path}")
-
-    @Slot(str)
-    def _on_export_error(self, err: str):
-        self.logger.error(f"❌ 保存XML文件失败: {err}")
-        QMessageBox.critical(self, "保存失败", f"无法写入文件，请检查权限或路径。\n错误信息: {err}")
-
-
-    # region UI State Management
-
-    def _update_ui_for_state(self, state: SenderState):
-        """根据任务状态统一更新 UI"""
-        self.state.sender_is_active = state in (SenderState.RUNNING, SenderState.STOPPING)
-
-        match state:
-            case SenderState.READY:
-                self.start_btn.setText("开始发送")
-                self.start_btn.setEnabled(True)
-                self._update_btn_style(False)
-                self._set_inputs_locked(False)
-                self.progress_bar.setFormat("%p%")
-
-            case SenderState.RUNNING:
-                self.start_btn.setText("紧急停止")
-                self.start_btn.setEnabled(True)
-                self._update_btn_style(True)
-                self._set_inputs_locked(True)
-                self.log_output.clear()
-                self.progress_bar.setValue(0)
-
-            case SenderState.STOPPING:
-                self.start_btn.setText("停止中...")
-                self.start_btn.setEnabled(False)
-                self.progress_bar.setFormat("%p% (正在停止...)")
-
-    # endregion
-
-    def _update_btn_style(self, running: bool):
-        """统一刷新按钮状态与图标的私有方法"""
-        state = "running" if running else "ready"
-        self.start_btn.setProperty("state", state)
-        self.start_btn.style().unpolish(self.start_btn)
-        self.start_btn.style().polish(self.start_btn)
-        self.start_btn.setIcon(self._icon_stop if running else self._icon_start)
-
     def _set_inputs_locked(self, locked: bool):
-        """
-        设置输入控件的锁定状态
-
-        Args:
-            locked (bool): True 表示锁定(不可编辑)，False 表示解锁(可编辑)。
-        """
+        """设置输入控件的锁定状态"""
         self.basic_group.set_inputs_locked(locked)
-        self.strategy_tabs.set_inputs_locked(locked)
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """鼠标拖拽文件进入页面区域"""
@@ -829,5 +640,3 @@ class SenderPage(QWidget):
             self.logger.info(f"📥 接收到拖拽文件: {file_path}")
             self.binding.load_file(file_path)
             event.acceptProposedAction()
-
-

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -1,11 +1,12 @@
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QFormLayout, QLabel, QCheckBox, QGroupBox
+    QWidget, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QCheckBox,
+    QGroupBox, QSpinBox, QDoubleSpinBox, QFrame
 )
 from PySide6.QtCore import Qt
 
 from .framework.binder import UIBinder
 
-from ..runtime.state.app_state import AppState
+from danmaku_sender.runtime.state.app_state import AppState
 
 
 class SettingsPage(QWidget):
@@ -44,6 +45,101 @@ class SettingsPage(QWidget):
         network_group.setLayout(network_layout)
         main_layout.addWidget(network_group)
 
+        # --- 发送延迟 ---
+        delay_group = QGroupBox("发送延迟")
+        delay_layout = QHBoxLayout()
+        delay_layout.setContentsMargins(10, 20, 10, 20)
+
+        delay_layout.addWidget(QLabel("随机间隔(秒):"))
+        self.min_delay = QDoubleSpinBox()
+        self.min_delay.setRange(0.1, 60.0)
+        self.min_delay.setValue(8.0)
+        self.min_delay.setSingleStep(0.5)
+        delay_layout.addWidget(self.min_delay)
+
+        delay_layout.addWidget(QLabel("-"))
+
+        self.max_delay = QDoubleSpinBox()
+        self.max_delay.setRange(0.1, 60.0)
+        self.max_delay.setValue(8.5)
+        self.max_delay.setSingleStep(0.5)
+        delay_layout.addWidget(self.max_delay)
+
+        delay_layout.addSpacing(15)
+        v_line = QFrame()
+        v_line.setFrameShape(QFrame.Shape.VLine)
+        v_line.setFrameShadow(QFrame.Shadow.Sunken)
+        delay_layout.addWidget(v_line)
+        delay_layout.addSpacing(15)
+
+        self.burst_enabled_cb = QCheckBox("爆发模式")
+        self.burst_enabled_cb.setToolTip("勾选启用爆发模式：每发 N 条后自动休息一段时间")
+        self.burst_enabled_cb.toggled.connect(self._on_burst_toggled)
+        delay_layout.addWidget(self.burst_enabled_cb)
+
+        delay_layout.addWidget(QLabel("每"))
+
+        self.burst_size = QSpinBox()
+        self.burst_size.setRange(2, 100)
+        self.burst_size.setValue(3)
+        delay_layout.addWidget(self.burst_size)
+
+        delay_layout.addWidget(QLabel("条，休息"))
+
+        self.burst_rest_min = QDoubleSpinBox()
+        self.burst_rest_min.setRange(0.0, 300.0)
+        self.burst_rest_min.setValue(10.0)
+        self.burst_rest_min.setFixedWidth(60)
+        delay_layout.addWidget(self.burst_rest_min)
+
+        delay_layout.addWidget(QLabel("-"))
+
+        self.burst_rest_max = QDoubleSpinBox()
+        self.burst_rest_max.setRange(0.0, 300.0)
+        self.burst_rest_max.setValue(20.0)
+        self.burst_rest_max.setFixedWidth(60)
+        delay_layout.addWidget(self.burst_rest_max)
+
+        delay_layout.addWidget(QLabel("秒"))
+
+        self._burst_controls: list[QWidget] = [
+            self.burst_size, self.burst_rest_min, self.burst_rest_max
+        ]
+
+        delay_layout.addStretch()
+        delay_group.setLayout(delay_layout)
+        main_layout.addWidget(delay_group)
+
+        # --- 自动终止 ---
+        stop_group = QGroupBox("自动终止")
+        stop_layout = QHBoxLayout()
+        stop_layout.setContentsMargins(10, 20, 10, 20)
+
+        stop_layout.addWidget(QLabel("已发送 >="))
+        self.stop_count = QSpinBox()
+        self.stop_count.setRange(0, 99999)
+        stop_layout.addWidget(self.stop_count)
+        stop_layout.addWidget(QLabel("条"))
+
+        stop_layout.addSpacing(20)
+        v_line2 = QFrame()
+        v_line2.setFrameShape(QFrame.Shape.VLine)
+        v_line2.setFrameShadow(QFrame.Shadow.Sunken)
+        stop_layout.addWidget(v_line2)
+        stop_layout.addSpacing(20)
+
+        stop_layout.addWidget(QLabel("已用时 >="))
+        self.stop_time = QSpinBox()
+        self.stop_time.setRange(0, 99999)
+        stop_layout.addWidget(self.stop_time)
+        stop_layout.addWidget(QLabel("分钟"))
+
+        stop_layout.addStretch()
+        stop_layout.addWidget(QLabel("(0为不限制)"))
+
+        stop_group.setLayout(stop_layout)
+        main_layout.addWidget(stop_group)
+
         main_layout.addStretch()
 
         info_label = QLabel("💡 账号管理请点击左上角头像区域。")
@@ -52,6 +148,10 @@ class SettingsPage(QWidget):
 
         self.setLayout(main_layout)
 
+    def _on_burst_toggled(self, checked: bool):
+        for ctrl in self._burst_controls:
+            ctrl.setEnabled(checked)
+
     def init_bindings(self) -> None:
         """将 UI 控件与全局状态 (AppState) 进行双向绑定"""
         UIBinder.bind(self.prevent_sleep_checkbox, self.state.sender_config, "prevent_sleep", clear_old=True)
@@ -59,3 +159,19 @@ class SettingsPage(QWidget):
 
         UIBinder.bind(self.prevent_sleep_checkbox, self.state.monitor_config, "prevent_sleep", clear_old=False)
         UIBinder.bind(self.proxy_checkbox, self.state.monitor_config, "use_system_proxy", clear_old=False)
+
+        # 发送延迟策略
+        config = self.state.sender_config
+        UIBinder.bind(self.min_delay, config, "min_delay")
+        UIBinder.bind(self.max_delay, config, "max_delay")
+        UIBinder.bind(self.burst_enabled_cb, config, "burst_enabled")
+        UIBinder.bind(self.burst_size, config, "burst_size")
+        UIBinder.bind(self.burst_rest_min, config, "rest_min")
+        UIBinder.bind(self.burst_rest_max, config, "rest_max")
+
+        # 自动终止规则
+        UIBinder.bind(self.stop_count, config, "stop_after_count")
+        UIBinder.bind(self.stop_time, config, "stop_after_time")
+
+        # 初始化爆发控件状态
+        self._on_burst_toggled(self.burst_enabled_cb.isChecked())


### PR DESCRIPTION
## Sourcery 总结

将发送策略迁移至设置页，并统一重构为以队列为中心的发送操作界面。

新功能：
- 在设置页集中配置发送延迟、爆发模式和自动终止规则。

问题修复：
- 确保队列任务使用最新的全局跳过已发送弹幕策略，而非仅依赖任务快照。

增强功能：
- 将发送流程统一为队列操作，移除单任务发送入口及相关状态处理。
- 重构底部操作区，集中提供队列启动、停止、状态和进度控制，并同步更新快捷键行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将发送策略迁移至设置页，并统一重构为以队列为中心的发送操作界面。

New Features:
- 在设置页集中配置发送延迟、爆发模式和自动终止规则。

Bug Fixes:
- 确保队列任务使用最新的全局跳过已发送弹幕策略，而非仅依赖任务快照。

Enhancements:
- 将发送流程统一为队列操作，移除单任务发送入口及相关状态处理。
- 重构底部操作区，集中提供队列启动、停止、状态和进度控制，并同步更新快捷键行为。

</details>