### PR TITLE
feat(queue): Stage 3.5 — 任务构建弹窗与 BasicParamsGroup 移除

### DIFF
--- a/src/danmaku_sender/controller/sender_controller.py
+++ b/src/danmaku_sender/controller/sender_controller.py
@@ -335,7 +335,11 @@ class QueueWorker(WorkerThread):
                         stopped_early = True
                         break
 
-                    if task.status != TaskStatus.PENDING:
+                    if task.status not in (TaskStatus.PENDING, TaskStatus.UNCONFIGURED):
+                        continue
+
+                    if task.status == TaskStatus.UNCONFIGURED:
+                        self.queue_state.update_task_status(task.task_id, TaskStatus.SKIPPED, "未配置弹幕")
                         continue
 
                     self.queue_state.current_index = idx
@@ -360,6 +364,7 @@ class QueueWorker(WorkerThread):
 
         except Exception as e:
             logger.error(f"队列执行发生未预期异常: {e}", exc_info=True)
+
         finally:
             self.queue_state.current_index = -1
             self.queueFinished.emit()

--- a/src/danmaku_sender/runtime/state/queue_state.py
+++ b/src/danmaku_sender/runtime/state/queue_state.py
@@ -41,9 +41,9 @@ class QueueState(QObject):
         logger.info(f"任务已加入队列: [{task.task_id}] {task.target.display_string} ({len(task.danmakus)} 条弹幕)")
 
     def remove_task(self, task_id: str) -> bool:
-        """移除指定任务（仅 PENDING 状态可移除）"""
+        """移除指定任务（仅 PENDING/UNCONFIGURED 状态可移除）"""
         for i, task in enumerate(self._tasks):
-            if task.task_id == task_id and task.status == TaskStatus.PENDING:
+            if task.task_id == task_id and task.status in (TaskStatus.PENDING, TaskStatus.UNCONFIGURED):
                 self._tasks.pop(i)
                 self.tasksChanged.emit()
                 logger.info(f"任务已从队列移除: [{task_id}]")
@@ -52,19 +52,21 @@ class QueueState(QObject):
 
     def move_task(self, task_id: str, direction: int) -> bool:
         """移动任务位置（direction: -1 上移, +1 下移）"""
+        movable = (TaskStatus.PENDING, TaskStatus.UNCONFIGURED)
         for i, task in enumerate(self._tasks):
-            if task.task_id == task_id and task.status == TaskStatus.PENDING:
+            if task.task_id == task_id and task.status in movable:
                 new_index = i + direction
-                if 0 <= new_index < len(self._tasks) and self._tasks[new_index].status == TaskStatus.PENDING:
+                if 0 <= new_index < len(self._tasks) and self._tasks[new_index].status in movable:
                     self._tasks[i], self._tasks[new_index] = self._tasks[new_index], self._tasks[i]
                     self.tasksChanged.emit()
                     return True
+
         return False
 
     def clear_completed(self):
-        """清除已完成/失败/跳过的任务（保留 PENDING 和 PAUSED）"""
+        """清除已完成/失败/跳过的任务（保留 PENDING、PAUSED、UNCONFIGURED）"""
         before = len(self._tasks)
-        self._tasks = [t for t in self._tasks if t.status in (TaskStatus.PENDING, TaskStatus.PAUSED)]
+        self._tasks = [t for t in self._tasks if t.status in (TaskStatus.PENDING, TaskStatus.PAUSED, TaskStatus.UNCONFIGURED)]
         removed = before - len(self._tasks)
         if removed > 0:
             self.tasksChanged.emit()

--- a/src/danmaku_sender/types/models/queue.py
+++ b/src/danmaku_sender/types/models/queue.py
@@ -10,6 +10,7 @@ from danmaku_sender.config import SenderConfig
 
 class TaskStatus(Enum):
     """队列任务状态"""
+    UNCONFIGURED = "未配置"
     PENDING = "等待中"
     RUNNING = "发送中"
     PAUSED = "已暂停"

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -189,9 +189,9 @@ class MainWindow(QMainWindow):
 
     def _init_shortcuts(self):
         """初始化全局快捷键"""
-        # Ctrl+O: 打开弹幕文件
-        self._sc_open = QShortcut(QKeySequence.StandardKey.Open, self)
-        self._sc_open.activated.connect(self.page_sender._select_file)
+        # Ctrl+N: 新建任务
+        self._sc_new = QShortcut(QKeySequence.StandardKey.New, self)
+        self._sc_new.activated.connect(self.page_sender._add_to_queue)
 
         # Ctrl+Enter: 启动队列
         self._sc_send = QShortcut(QKeySequence(Qt.Key.Key_Return | Qt.KeyboardModifier.ControlModifier), self)

--- a/src/danmaku_sender/ui/sender/components/queue_table.py
+++ b/src/danmaku_sender/ui/sender/components/queue_table.py
@@ -48,6 +48,8 @@ class ProgressBarDelegate(QStyledItemDelegate):
                 bar.text = "跳过"
             case TaskStatus.PAUSED:
                 bar.text = "暂停"
+            case TaskStatus.UNCONFIGURED:
+                bar.text = "未配置"
             case TaskStatus.PENDING:
                 bar.text = "等待"
 
@@ -152,6 +154,7 @@ class QueueTableModel(QAbstractTableModel):
                 TaskStatus.FAILED: QColor("#c0392b"),
                 TaskStatus.SKIPPED: QColor("#95a5a6"),
                 TaskStatus.PAUSED: QColor("#9b59b6"),
+                TaskStatus.UNCONFIGURED: QColor("#7f8c8d"),
             }.get(task.status, QColor("#f39c12")))
         return None
 
@@ -173,7 +176,7 @@ class QueueTableModel(QAbstractTableModel):
         if self.queue_running:
             return default
         task = self._tasks[index.row()]
-        if task.status == TaskStatus.PENDING:
+        if task.status in (TaskStatus.PENDING, TaskStatus.UNCONFIGURED):
             return default | Qt.ItemFlag.ItemIsDragEnabled
         return default
 

--- a/src/danmaku_sender/ui/sender/components/task_builder_dialog.py
+++ b/src/danmaku_sender/ui/sender/components/task_builder_dialog.py
@@ -1,0 +1,209 @@
+import logging
+
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QLabel, QLineEdit,
+    QPushButton, QComboBox, QFileDialog, QMessageBox, QGroupBox
+)
+from PySide6.QtCore import Qt, Signal, Slot
+
+from danmaku_sender.controller.video_controller import VideoController
+from danmaku_sender.types.models.video import VideoInfo
+from danmaku_sender.types.models.queue import QueueTask, TaskStatus
+from danmaku_sender.types.models.common import VideoTarget
+from danmaku_sender.config import ApiAuthConfig, SenderConfig
+from danmaku_sender.runtime.state.app_state import AppState
+from danmaku_sender.service.danmaku_parser import DanmakuParser
+from danmaku_sender.utils.string_utils import parse_bilibili_link
+
+
+logger = logging.getLogger(__name__)
+
+
+class TaskBuilderDialog(QDialog):
+    """任务构建弹窗：选择视频 → 选择分P → 选择弹幕文件 → 添加到队列"""
+
+    taskCreated = Signal(QueueTask)  # 每创建一个任务就发射
+
+    def __init__(self, state: AppState, parent=None):
+        super().__init__(parent)
+        self.state = state
+        self.video_controller = VideoController(self)
+        self._video_info: VideoInfo | None = None
+        self._selected_files: list[str] = []
+        self._pending_part_index: int | None = None
+
+        self.setWindowTitle("添加任务到队列")
+        self.setMinimumWidth(500)
+        self._create_ui()
+        self._connect_signals()
+
+    def _create_ui(self):
+        layout = QVBoxLayout(self)
+
+        group = QGroupBox("新建任务")
+        form = QFormLayout(group)
+        form.setSpacing(10)
+
+        # 目标视频
+        bv_row = QHBoxLayout()
+        self._bv_input = QLineEdit()
+        self._bv_input.setPlaceholderText("输入BV号或视频链接")
+        self._fetch_btn = QPushButton("获取视频信息")
+        self._fetch_btn.setFixedWidth(100)
+        bv_row.addWidget(self._bv_input)
+        bv_row.addWidget(self._fetch_btn)
+        form.addRow("目标视频:", bv_row)
+
+        # 分P选择
+        self._part_combo = QComboBox()
+        self._part_combo.setPlaceholderText("请先获取视频信息")
+        self._part_combo.setEnabled(False)
+        form.addRow("分P选择:", self._part_combo)
+
+        # 弹幕文件
+        file_row = QHBoxLayout()
+        self._file_input = QLineEdit()
+        self._file_input.setPlaceholderText("未选择文件（可稍后添加）")
+        self._file_input.setReadOnly(True)
+        self._file_btn = QPushButton("选择文件")
+        self._file_btn.setFixedWidth(80)
+        file_row.addWidget(self._file_input, stretch=1)
+        file_row.addWidget(self._file_btn)
+        form.addRow("弹幕文件:", file_row)
+
+        layout.addWidget(group)
+
+        # --- 按钮 ---
+        btn_layout = QHBoxLayout()
+        self._btn_add = QPushButton("添加到队列")
+        self._btn_add.setFixedWidth(100)
+        self._btn_add.setEnabled(False)
+
+        btn_layout.addStretch()
+        btn_layout.addWidget(self._btn_add)
+
+        layout.addLayout(btn_layout)
+
+    def _connect_signals(self):
+        self._fetch_btn.clicked.connect(self._fetch_video)
+        self._file_btn.clicked.connect(self._select_files)
+        self._btn_add.clicked.connect(self._add_task)
+        self._part_combo.currentIndexChanged.connect(self._update_add_button)
+
+        self.video_controller.fetchSucceeded.connect(self._on_fetch_succeeded)
+        self.video_controller.fetchFailed.connect(self._on_fetch_failed)
+
+    def _update_add_button(self):
+        """根据状态决定添加按钮是否可用"""
+        has_part = self._part_combo.currentIndex() >= 0 and self._part_combo.currentData() is not None
+        self._btn_add.setEnabled(has_part)
+
+    @Slot()
+    def _fetch_video(self):
+        raw = self._bv_input.text().strip()
+        if not raw:
+            return
+
+        bvid, p_index = parse_bilibili_link(raw)
+        if not bvid:
+            QMessageBox.warning(self, "格式错误", "未能识别有效的 BV 号。")
+            return
+
+        self._bv_input.setText(bvid)
+        self._pending_part_index = p_index
+        self._fetch_btn.setEnabled(False)
+        self._fetch_btn.setText("获取中...")
+        self._part_combo.clear()
+        self._part_combo.setEnabled(False)
+
+        self.video_controller.fetch_single_info(bvid, self.state.get_api_auth())
+
+    @Slot(str, VideoInfo)
+    def _on_fetch_succeeded(self, bvid: str, info: VideoInfo):
+        self._video_info = info
+        self._fetch_btn.setEnabled(True)
+        self._fetch_btn.setText("获取视频信息")
+        self._part_combo.setEnabled(True)
+
+        self._part_combo.clear()
+        for p in info.parts:
+            if p.cid:
+                self._part_combo.addItem(f"P{p.page} - {p.title}", userData={'cid': p.cid, 'page': p.page})
+
+        if self._part_combo.count() > 0:
+            if self._pending_part_index is not None and 0 <= self._pending_part_index < self._part_combo.count():
+                self._part_combo.setCurrentIndex(self._pending_part_index)
+            else:
+                self._part_combo.setCurrentIndex(0)
+            self._pending_part_index = None
+
+        self._update_add_button()
+
+    @Slot(str, str)
+    def _on_fetch_failed(self, bvid: str, error_msg: str):
+        self._fetch_btn.setEnabled(True)
+        self._fetch_btn.setText("获取视频信息")
+        QMessageBox.warning(self, "获取失败", f"无法获取视频信息:\n{error_msg}")
+
+    @Slot()
+    def _select_files(self):
+        files, _ = QFileDialog.getOpenFileNames(
+            self, "选择弹幕XML文件", "", "XML Files (*.xml)"
+        )
+        if files:
+            self._selected_files = files
+            if len(files) == 1:
+                self._file_input.setText(files[0].split("/")[-1].split("\\")[-1])
+            else:
+                self._file_input.setText(f"已选择 {len(files)} 个文件")
+        else:
+            self._selected_files = []
+            self._file_input.clear()
+
+    @Slot()
+    def _add_task(self):
+        if not self._video_info:
+            return
+
+        data = self._part_combo.currentData()
+        if not data:
+            return
+
+        cid = data['cid']
+        page = data['page']
+        part_name = self._part_combo.currentText()
+
+        target = VideoTarget(
+            bvid=self._video_info.bvid,
+            cid=cid,
+            title=self._video_info.title,
+        )
+
+        # 解析弹幕文件（如果选了的话）
+        danmakus = []
+        if self._selected_files:
+            parser = DanmakuParser()
+            file_idx = min(self._part_combo.currentIndex(), len(self._selected_files) - 1)
+            try:
+                danmakus = parser.parse_xml_file(self._selected_files[file_idx])
+            except Exception as e:
+                QMessageBox.warning(self, "解析失败", f"弹幕文件解析失败:\n{e}")
+                return
+
+        task = QueueTask(
+            target=target,
+            danmakus=danmakus,
+            config_snapshot=self.state.sender_config.model_copy(),
+            part_name=part_name,
+        )
+
+        # 如果没有弹幕，标记为未配置
+        if not danmakus:
+            task.status = TaskStatus.UNCONFIGURED
+
+        self.taskCreated.emit(task)
+        logger.info(f"任务已创建: {target.display_string} ({len(danmakus)} 条弹幕, {task.status.value})")
+
+        # 添加后保留分P选择，只清空文件选择
+        self._selected_files = []
+        self._file_input.clear()

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import Qt, QPoint, QModelIndex, QDateTime, Signal, Slot
 
 from .components import BasicParamsGroup, QueueTableModel
 from .components.queue_table import ProgressBarDelegate
+from .components.task_builder_dialog import TaskBuilderDialog
 from .data_binding import SenderDataBinding
 
 from danmaku_sender.ui.framework.style_loader import SvgIcon
@@ -102,7 +103,7 @@ class SenderPage(QWidget):
 
         queue_btn_layout = QHBoxLayout()
 
-        self._btn_add_to_queue = QPushButton("添加到队列")
+        self._btn_add_to_queue = QPushButton("新建任务")
         self._btn_add_to_queue.setIcon(SvgIcon("start.svg"))
         self._btn_add_to_queue.setFixedWidth(120)
         self._btn_add_to_queue.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -299,7 +300,7 @@ class SenderPage(QWidget):
             return
 
         menu = QMenu(self)
-        is_pending = task.status == TaskStatus.PENDING
+        is_pending = task.status in (TaskStatus.PENDING, TaskStatus.UNCONFIGURED)
 
         menu.addAction("查看详情", lambda: self._show_task_detail(task))
         menu.addSeparator()
@@ -361,37 +362,19 @@ class SenderPage(QWidget):
         if not indexes:
             return
         task = self._queue_model.get_task_at(indexes[0].row())
-        if task and task.status == TaskStatus.PENDING:
+        if task and task.status in (TaskStatus.PENDING, TaskStatus.UNCONFIGURED):
             self._remove_task(task.task_id)
 
     @Slot()
     def _add_to_queue(self):
-        """将当前配置添加到发送队列"""
-        status = self.sender_controller.send_status
-        if status == SenderStatus.NOT_READY:
-            QMessageBox.warning(self, "条件不足", "请确保 BV号、分P、弹幕文件 均已就绪。")
-            return
-        if status == SenderStatus.NO_CREDENTIALS:
-            QMessageBox.warning(self, "凭证缺失", "请先登入账号。")
-            return
-        if status == SenderStatus.EDITOR_DIRTY:
-            QMessageBox.warning(self, "存在未保存的修改", "请先在编辑器中应用修改。")
-            return
+        """打开任务构建弹窗"""
+        dialog = TaskBuilderDialog(self.state, self)
+        dialog.taskCreated.connect(self._on_task_created)
+        dialog.exec()
 
-        state = self.state
-        target = VideoTarget(
-            bvid=state.video_state.bvid,
-            cid=state.video_state.selected_cid,
-            title=state.video_state.video_title,
-        )
-        task = QueueTask(
-            target=target,
-            danmakus=list(state.video_state.loaded_danmakus),
-            config_snapshot=state.sender_config.model_copy(),
-            part_name=state.video_state.selected_part_name,
-        )
-        state.queue_state.add_task(task)
-        self.logger.info(f"已添加到队列: {target.display_string} ({len(task.danmakus)} 条弹幕)")
+    def _on_task_created(self, task: QueueTask):
+        """弹窗创建任务后的回调"""
+        self.state.queue_state.add_task(task)
 
     @Slot()
     def _start_queue(self):

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent, QShortcut, QKeySequence
 from PySide6.QtCore import Qt, QPoint, QModelIndex, QDateTime, Signal, Slot
 
-from .components import BasicParamsGroup, QueueTableModel
+from .components import QueueTableModel
 from .components.queue_table import ProgressBarDelegate
 from .components.task_builder_dialog import TaskBuilderDialog
 from .data_binding import SenderDataBinding
@@ -55,10 +55,6 @@ class SenderPage(QWidget):
         main_layout = QVBoxLayout(self)
         main_layout.setSpacing(10)
         main_layout.setContentsMargins(10, 10, 10, 10)
-
-        # --- 基础参数区 ---
-        self.basic_group = BasicParamsGroup(self.state)
-        main_layout.addWidget(self.basic_group)
 
         # --- 队列区 ---
         queue_group = QGroupBox("发送队列")
@@ -186,23 +182,11 @@ class SenderPage(QWidget):
         self._drop_overlay.hide()
 
     def _connect_signals(self):
-        # 子组件信号
-        self.basic_group.file_btn.clicked.connect(self._select_file)
-        self.basic_group.fetch_btn.clicked.connect(self._fetch_video_info)
-        self.basic_group.part_combo.currentIndexChanged.connect(self._on_part_selected)
-
         # 队列按钮
         self._btn_add_to_queue.clicked.connect(self._add_to_queue)
         self._btn_clear_completed.clicked.connect(self._clear_completed)
         self._btn_start_queue.clicked.connect(self._start_queue)
         self._btn_stop_queue.clicked.connect(self._stop_queue)
-
-        # DataBinding
-        self.binding.fileLoaded.connect(self._on_file_loaded)
-        self.binding.fileLoadFailed.connect(self._on_file_load_failed)
-        self.binding.videoFetchStarted.connect(self._on_fetch_started)
-        self.binding.videoFetched.connect(self._on_fetch_succeeded)
-        self.binding.videoFetchFailed.connect(self._on_fetch_failed)
 
         # SenderController (队列)
         self.sender_controller.queueTaskStarted.connect(self._on_queue_task_started)
@@ -219,70 +203,12 @@ class SenderPage(QWidget):
 
     def init_bindings(self):
         """将 UI 控件与 AppState 进行双向绑定"""
-        self.basic_group.init_bindings()
-
-        # 监听共享数据变化（编辑器提交等场景）
-        self.state.video_state.subscribe("loaded_danmakus", self._on_loaded_danmakus_changed)
-
-    def _on_loaded_danmakus_changed(self, _value):
-        """编辑器提交弹幕后自动刷新发射器 UI"""
-        count = self.state.video_state.danmaku_count
-        if count > 0:
-            self.basic_group.file_input.setText(f"来自编辑器: {count} 条弹幕")
-        else:
-            self.basic_group.file_input.clear()
+        pass
 
     def append_log(self, message: str):
         """外部调用的日志接口"""
         self.log_output.append(message)
         self.log_output.moveCursor(QTextCursor.MoveOperation.End)
-
-    @Slot(str, int)
-    def _on_file_loaded(self, filename: str, count: int):
-        self.basic_group.file_input.setEnabled(True)
-        if count > 0:
-            self.basic_group.file_input.setText(filename)
-            self.logger.info(f"✅ 文件解析成功，共 {count} 条弹幕。")
-        else:
-            self.basic_group.file_input.clear()
-            self.logger.warning("⚠️ 文件解析完成但无有效弹幕。")
-
-    @Slot(str, str)
-    def _on_file_load_failed(self, error_msg: str, _extra: str):
-        self.basic_group.file_input.setEnabled(True)
-        self.basic_group.file_input.clear()
-        self.logger.error(f"❌ 解析失败: {error_msg}")
-        QMessageBox.critical(self, "解析失败", error_msg)
-
-
-    # region Slots
-    # region Slots Internal
-    @Slot()
-    def _select_file(self):
-        """文件选择逻辑"""
-        self.binding.select_file()
-
-    @Slot()
-    def _fetch_video_info(self):
-        """获取视频信息"""
-        raw_input = self.basic_group.bv_input.text().strip()
-        if not raw_input:
-            QMessageBox.warning(self, "输入错误", "请输入BV号或视频链接")
-            return
-
-        bvid = self.binding.fetch_video_info(raw_input)
-        if not bvid:
-            QMessageBox.warning(self, "格式错误", "未能识别有效的 BV 号。\n请检查输入内容是否正确。")
-            return
-
-        self.basic_group.bv_input.setText(bvid)
-
-    @Slot(int)
-    def _on_part_selected(self, index: int):
-        """处理分P选择变化"""
-        data = self.basic_group.part_combo.itemData(index)
-        part_name = self.basic_group.part_combo.currentText()
-        self.binding.select_part(index, data, part_name)
 
     @Slot(QModelIndex)
     def _on_queue_double_clicked(self, index: QModelIndex):
@@ -406,49 +332,6 @@ class SenderPage(QWidget):
 
     # endregion
     # region Slots VideoController
-
-    @Slot()
-    def _on_fetch_started(self):
-        """UI 层: 响应加载中状态"""
-        self.basic_group.fetch_btn.setEnabled(False)
-        self.basic_group.fetch_btn.setText("获取中")
-        self.basic_group.part_combo.clear()
-        self.basic_group.part_combo.setEnabled(False)
-
-    @Slot(str, object)
-    def _on_fetch_succeeded(self, bvid: str, info: VideoInfo):
-        """获取成功: 填充分P下拉框"""
-        self.basic_group.fetch_btn.setEnabled(True)
-        self.basic_group.fetch_btn.setText("获取分P")
-        self.basic_group.part_combo.setEnabled(True)
-
-        for p in info.parts:
-            if not p.cid:
-                continue
-            part_name = f"P{p.page} - {p.title}"
-            self.basic_group.part_combo.addItem(part_name, userData={'cid': p.cid, 'duration': p.duration})
-            self.state.video_state.cid_parts_map[p.cid] = part_name
-
-        if info.parts:
-            pending = self.binding.pending_part_index
-            if pending is not None and 0 <= pending < self.basic_group.part_combo.count():
-                self.basic_group.part_combo.setCurrentIndex(pending)
-                self.logger.info(f"🔗 智能链接解析: 自动定位到第 {pending + 1} P")
-            else:
-                self.basic_group.part_combo.setCurrentIndex(0)
-            self.binding.clear_pending_part_index()
-
-    @Slot(str, str)
-    def _on_fetch_failed(self, bvid: str, error_msg: str):
-        """获取失败: 恢复 UI 状态并弹窗提示"""
-        self.basic_group.fetch_btn.setEnabled(True)
-        self.basic_group.fetch_btn.setText("获取分P")
-
-        self.basic_group.part_combo.clear()
-        self.basic_group.part_combo.addItem(f"获取失败，请重试")
-        self.basic_group.part_combo.setEnabled(False)
-
-        QMessageBox.warning(self, "获取失败", f"无法获取视频信息:\n{error_msg}")
 
     # endregion
     # region Slots SenderController

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QTableView, QHeaderView, QAbstractItemView, QMenu
 )
 from PySide6.QtGui import QTextCursor, QDragEnterEvent, QDropEvent, QShortcut, QKeySequence
-from PySide6.QtCore import Qt, QPoint, QModelIndex, QDateTime, Signal, Slot
+from PySide6.QtCore import Qt, QPoint, QModelIndex, QDateTime, QTimer, Signal, Slot
 
 from .components import QueueTableModel
 from .components.queue_table import ProgressBarDelegate
@@ -96,6 +96,16 @@ class SenderPage(QWidget):
         QShortcut(QKeySequence.StandardKey.Delete, self._queue_table, self._delete_selected_task)
 
         queue_layout.addWidget(self._queue_table)
+
+        # 空状态引导
+        self._empty_hint = QLabel("队列为空  点击「新建任务」添加发送任务", self._queue_table.viewport())
+        self._empty_hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._empty_hint.setStyleSheet("color: #888; font-size: 14px;")
+        self._empty_hint.setVisible(False)
+        self._queue_model.modelReset.connect(self._update_empty_hint)
+
+        # 布局完成后再定位，避免 viewport geometry 为零
+        QTimer.singleShot(0, self._update_empty_hint)
 
         queue_btn_layout = QHBoxLayout()
 
@@ -344,6 +354,17 @@ class SenderPage(QWidget):
         self.state.queue_state._tasks = reordered_tasks
         self.state.queue_state.tasksChanged.emit()
 
+    def _update_empty_hint(self):
+        self._empty_hint.setVisible(self._queue_model.rowCount() == 0)
+        self._reposition_empty_hint()
+
+    def _reposition_empty_hint(self):
+        self._empty_hint.setGeometry(self._queue_table.viewport().rect())
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._reposition_empty_hint()
+
     def _on_queue_changed(self):
         self._queue_model.set_tasks(self.state.queue_state.tasks)
 
@@ -452,20 +473,13 @@ class SenderPage(QWidget):
         self._btn_stop_queue.setVisible(running)
 
         if running:
-            self._set_inputs_locked(True)
             self.log_output.clear()
             self.progress_bar.setValue(0)
             self.progress_bar.setFormat("%p%")
-        else:
-            self._set_inputs_locked(False)
             self.progress_bar.setFormat("%p%")
 
     # endregion
     # endregion
-
-    def _set_inputs_locked(self, locked: bool):
-        """设置输入控件的锁定状态"""
-        self.basic_group.set_inputs_locked(locked)
 
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
         """鼠标拖拽文件进入页面区域"""

--- a/src/danmaku_sender/ui/settings_page.py
+++ b/src/danmaku_sender/ui/settings_page.py
@@ -140,6 +140,17 @@ class SettingsPage(QWidget):
         stop_group.setLayout(stop_layout)
         main_layout.addWidget(stop_group)
 
+        # --- 断点续传 ---
+        resume_group = QGroupBox("断点续传")
+        resume_layout = QFormLayout()
+
+        self.skip_sent_cb = QCheckBox("跳过已发送的弹幕（基于历史记录去重）")
+        self.skip_sent_cb.setToolTip("启用后，发送前会查询历史记录，自动跳过已成功发送过的弹幕。")
+
+        resume_layout.addRow(self.skip_sent_cb)
+        resume_group.setLayout(resume_layout)
+        main_layout.addWidget(resume_group)
+
         main_layout.addStretch()
 
         info_label = QLabel("💡 账号管理请点击左上角头像区域。")
@@ -172,6 +183,9 @@ class SettingsPage(QWidget):
         # 自动终止规则
         UIBinder.bind(self.stop_count, config, "stop_after_count")
         UIBinder.bind(self.stop_time, config, "stop_after_time")
+
+        # 断点续传
+        UIBinder.bind(self.skip_sent_cb, config, "skip_sent")
 
         # 初始化爆发控件状态
         self._on_burst_toggled(self.burst_enabled_cb.isChecked())


### PR DESCRIPTION
## Sourcery 总结

引入基于对话框的队列任务创建功能，并在整个队列管理和发送流程中支持未配置任务。

新功能：
- 添加任务构建器对话框，用于在创建队列任务前选择视频、分 P 以及可选的弹幕文件。
- 为不包含弹幕内容的队列项目添加明确的未配置任务状态，并支持其显示和执行处理。
- 添加设置选项，以便在恢复发送时跳过之前已发送的弹幕。

增强功能：
- 将发送器页面中的内联基础参数控件替换为专注于队列的界面，并添加空队列引导。
- 允许对待处理任务和未配置任务进行重新排序、移除，并在清除已完成任务时保留这些任务。
- 将全局新建任务快捷键改为打开任务创建界面。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

引入基于对话框的队列任务创建流程，并在整个队列管理和发送过程中支持未配置任务。

新功能：
- 添加基于对话框的工作流，通过选择视频、分P以及可选的弹幕文件来创建队列任务。
- 当未提供弹幕文件时，支持明确的未配置任务，包括显示、队列管理和执行处理。
- 添加一项设置，以便在恢复发送时跳过之前已发送的弹幕。

增强功能：
- 将发送页面中的内联基础参数控件替换为以队列为中心的界面，并在队列为空时提供操作指引。
- 允许对待处理任务和未配置任务进行重新排序或移除；清除已完成项目时保留未配置任务。
- 将全局新建任务快捷键改为打开任务创建对话框。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入基于对话框的队列任务创建功能，并扩展队列管理和发送功能，以处理未配置弹幕的任务。

新功能：
- 添加基于对话框的工作流，通过选择视频、分 P 和可选的弹幕文件来创建队列任务。
- 当未提供弹幕时，支持显式的未配置队列任务，包括显示、管理和执行处理。
- 添加一项设置，用于在恢复发送时跳过已发送的弹幕。

改进：
- 将内联发送器参数替换为以队列为中心的任务创建界面，并在队列为空时提供引导。
- 允许对待处理任务和未配置任务重新排序或移除，同时在清除已完成条目时保留未配置任务。
- 将全局新建任务快捷键改为打开任务创建对话框。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce dialog-based queue task creation and extend queue management and sending to handle tasks without configured danmaku.

New Features:
- Add a dialog-based workflow for creating queue tasks by selecting a video, part, and optional danmaku file.
- Support explicit unconfigured queue tasks when no danmaku is provided, including display, management, and execution handling.
- Add a setting to skip danmaku that were already sent when resuming delivery.

Enhancements:
- Replace inline sender parameters with a queue-focused task creation interface and empty-queue guidance.
- Allow pending and unconfigured tasks to be reordered or removed while preserving unconfigured tasks when clearing completed entries.
- Change the global new-task shortcut to open the task creation dialog.

</details>

</details>

</details>