### PR TITLE
feat(queue): Stage 3.8 — 修复日志路由与噪声抑制

### DIFF
--- a/src/danmaku_sender/runtime/infra/log_utils.py
+++ b/src/danmaku_sender/runtime/infra/log_utils.py
@@ -11,7 +11,7 @@ from danmaku_sender.config.app_meta import AppInfo
 
 class LogNamespace:
     """日志命名空间契约（基于模块路径）"""
-    SENDER_PREFIXES = ("danmaku_sender.service.sender", "danmaku_sender.ui.sender")
+    SENDER_PREFIXES = ("danmaku_sender.service.sender", "danmaku_sender.ui.sender", "danmaku_sender.controller.sender_controller")
     MONITOR_PREFIXES = ("danmaku_sender.service.bili_monitor", "danmaku_sender.ui.monitor_page", "danmaku_sender.controller.monitor_controller")
 
 
@@ -137,5 +137,7 @@ def init_app_logging(log_dir: Path):
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("peewee").setLevel(logging.WARNING)
+    logging.getLogger("keyring").setLevel(logging.WARNING)
+    logging.getLogger("win32ctypes").setLevel(logging.WARNING)
 
     logging.info(f"日志系统初始化完成。日志路径: {log_file_path}")


### PR DESCRIPTION
- sender_controller 日志路由到发送面板
- keyring、win32ctypes 日志抑制为 WARNING 级别

## Sourcery 总结

修正发送器日志路由，并抑制来自 keyring 和 win32ctypes 的低严重性噪音。

错误修复：
- 将发送器控制器日志路由到发送器面板。
- 将 keyring 和 win32ctypes 的日志级别限制为 WARNING 及以上，以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct sender log routing and suppress low-severity noise from keyring and win32ctypes.

Bug Fixes:
- Route sender controller logs to the sender panel.
- Reduce keyring and win32ctypes log noise by limiting them to WARNING level and above.

</details>