### PR TITLE
feat(queue): Stage 4A — 编辑器改为发射器附属弹窗

### DIFF
--- a/src/danmaku_sender/controller/editor_controller.py
+++ b/src/danmaku_sender/controller/editor_controller.py
@@ -8,6 +8,7 @@ from danmaku_sender.service.editor_session import EditorSession
 from danmaku_sender.runtime.state.app_state import AppState
 from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.editor_types import ViewItem, InsertPosition
+from danmaku_sender.types.models.queue import QueueTask
 from danmaku_sender.service.danmaku_parser import DanmakuParser
 from danmaku_sender.service.danmaku_exporter import export_danmakus_to_xml
 
@@ -16,16 +17,17 @@ class EditorController(QObject):
     """
     编辑器业务控制器 (Mediator / ViewModel)
 
-    负责桥接 UI、AppState 与 EditorSession。
+    负责桥接 UI、QueueTask 与 EditorSession。
+    编辑器作为发射器的附属弹窗，直接编辑 QueueTask 的弹幕数据。
     """
     dataChanged = Signal()
 
-    def __init__(self, state: AppState, parent=None):
+    def __init__(self, task: QueueTask, state: AppState, parent=None):
         super().__init__(parent)
         self.logger = logging.getLogger(__name__)
+        self.task = task
         self.state = state
         self.session = EditorSession()
-        self._is_dialog_mode = False  # 是否为弹窗模式（直接编辑任务的弹幕数据）
 
     # region Computed Properties for UI
 
@@ -36,16 +38,13 @@ class EditorController(QObject):
 
     @property
     def source_data_exists(self) -> bool:
-        """全局状态中是否有待加载的源数据"""
-        # 弹窗模式下，数据已经在 session 里了
-        if self._is_dialog_mode:
-            return self.has_data
-        return bool(self.state.video_state.loaded_danmakus)
+        """是否有待加载的源数据（任务的弹幕数据）"""
+        return bool(self.task.danmakus)
 
     @property
     def has_video_context(self) -> bool:
         """是否拥有关联的视频上下文（BVID/CID）"""
-        return bool(self.state.video_state.selected_cid)
+        return bool(self.task.target.bvid) and bool(self.task.target.cid)
 
     @property
     def is_dirty(self) -> bool:
@@ -65,23 +64,23 @@ class EditorController(QObject):
     # endregion
     # region Workflow Actions
 
-    def create_new_workspace(self):
-        """新建空白工作区并清除视频上下文"""
-        self.state.video_state.loaded_danmakus =[
-            Danmaku(msg="在这里输入你的第一条弹幕吧", progress=0)
-        ]
-        self.state.video_state.bvid = ""
-        self.state.video_state.selected_cid = None
-        self.state.video_state.video_title = ""
+    def load_from_task(self) -> bool:
+        """从任务加载弹幕数据到沙盒，并执行初次校验"""
+        if not self.task.danmakus:
+            return False
 
-        self.load_from_state()
+        self.session.load_data(self.task.danmakus)
+        self.run_validation()
+        self.session.mark_head_errors()  # 锁定初始错误快照
+        self.session.set_dirty(False)
+        self.dataChanged.emit()
+        return self.active_error_count > 0
 
     def import_xml_to_workspace(self, file_path: str, on_success: Callable[[int], None], on_error: Callable[[str], None]):
         """
         异步导入 XML 文件到工作区：解析在后台线程执行，状态更新在 UI 线程回调。
 
-        注意: on_success / on_error 回调由 Qt 信号机制保证在主线程执行，
-        因此回调内可安全操作 UI 状态。
+        注意: 导入弹幕会替换当前工作区的内容，但保留任务的视频上下文。
 
         Args:
             file_path: XML 文件路径
@@ -95,6 +94,23 @@ class EditorController(QObject):
             lambda err: on_error(str(err)),
             file_path,
         )
+
+    def _apply_parsed_to_workspace(self, parsed_dms: list[Danmaku] | None) -> int:
+        """
+        将已解析的弹幕列表写入工作区（不清除视频上下文）。
+
+        Returns:
+            int: 成功解析的弹幕数量
+        """
+        if not parsed_dms:
+            return 0
+
+        self.session.load_data(parsed_dms)
+        self.run_validation()
+        self.session.mark_head_errors()
+        self.session.set_dirty(False)
+        self.dataChanged.emit()
+        return len(parsed_dms)
 
     def export_to_xml(
         self,
@@ -111,69 +127,6 @@ class EditorController(QObject):
             danmakus, file_path,
         )
 
-    def _apply_parsed_to_workspace(self, parsed_dms: list[Danmaku] | None) -> int:
-        """
-        将已解析的弹幕列表写入工作区，清除视频上下文，拉入编辑器沙盒。
-
-        Returns:
-            int: 成功解析的弹幕数量
-        """
-        if not parsed_dms:
-            return 0
-
-        self.state.video_state.loaded_danmakus = parsed_dms
-        self.state.video_state.bvid = ""
-        self.state.video_state.selected_cid = None
-        self.state.video_state.video_title = ""
-
-        self.load_from_state()
-        return len(parsed_dms)
-
-    def load_from_state(self) -> bool:
-        """从 AppState 检出数据到沙盒，并执行初次校验"""
-        source = self.state.video_state.loaded_danmakus
-        if not source:
-            return False
-
-        self.session.load_data(source)
-        self.run_validation()
-        self.session.mark_head_errors()  # 锁定初始错误快照
-        self.session.set_dirty(False)
-        self.dataChanged.emit()
-        return self.active_error_count > 0
-
-    def load_from_danmakus(self, danmakus: list[Danmaku]) -> bool:
-        """从弹幕列表加载数据到沙盒，并执行初次校验
-
-        用于编辑器弹窗直接编辑 QueueTask 的弹幕数据。
-
-        Args:
-            danmakus: 弹幕列表
-
-        Returns:
-            是否有问题弹幕
-        """
-        if not danmakus:
-            return False
-
-        self._is_dialog_mode = True
-        self.session.load_data(danmakus)
-        self.run_validation()
-        self.session.mark_head_errors()  # 锁定初始错误快照
-        self.session.set_dirty(False)
-        self.dataChanged.emit()
-        return self.active_error_count > 0
-
-    def commit_to_state(self) -> tuple[int, int, int]:
-        """将修改结果提交回 AppState，清空沙盒"""
-        final_list, fixed, removed = self.session.get_committed_data()
-        self.state.video_state.loaded_danmakus = final_list
-
-        # 提交后重置沙盒
-        self.session.load_data([])
-        self.dataChanged.emit()
-        return len(final_list), fixed, removed
-
     def get_working_danmakus(self) -> list[Danmaku]:
         """提取当前工作区中所有未删除的弹幕 (供导出 XML 用)"""
         if not self.session.has_active_session:
@@ -185,11 +138,16 @@ class EditorController(QObject):
         ]
 
     def run_validation(self):
-        """执行校验：自动向沙盒注入最新的校验参数"""
+        """执行校验：自动向沙盒注入最新的校验参数
+
+        如果任务有关联的视频上下文，使用视频时长进行时间越界检查；
+        否则跳过时间检查（duration=-1）。
+        """
         duration = -1
-        # 弹窗模式下不检查 video_context，直接使用 -1（跳过时间检查）
-        if not self._is_dialog_mode and self.has_video_context:
-            duration = self.state.video_state.selected_part_duration_ms
+        if self.has_video_context:
+            # 使用任务关联的视频时长（从 task.target 获取，可能需要从 API 查询）
+            # 当前先使用 -1 跳过，后续可接入视频时长查询
+            duration = -1
 
         config = self.state.validation_config
         self.session.validate(duration_ms=duration, config=config)

--- a/src/danmaku_sender/controller/editor_controller.py
+++ b/src/danmaku_sender/controller/editor_controller.py
@@ -25,6 +25,7 @@ class EditorController(QObject):
         self.logger = logging.getLogger(__name__)
         self.state = state
         self.session = EditorSession()
+        self._is_dialog_mode = False  # 是否为弹窗模式（直接编辑任务的弹幕数据）
 
     # region Computed Properties for UI
 
@@ -36,6 +37,9 @@ class EditorController(QObject):
     @property
     def source_data_exists(self) -> bool:
         """全局状态中是否有待加载的源数据"""
+        # 弹窗模式下，数据已经在 session 里了
+        if self._is_dialog_mode:
+            return self.has_data
         return bool(self.state.video_state.loaded_danmakus)
 
     @property
@@ -138,6 +142,28 @@ class EditorController(QObject):
         self.dataChanged.emit()
         return self.active_error_count > 0
 
+    def load_from_danmakus(self, danmakus: list[Danmaku]) -> bool:
+        """从弹幕列表加载数据到沙盒，并执行初次校验
+
+        用于编辑器弹窗直接编辑 QueueTask 的弹幕数据。
+
+        Args:
+            danmakus: 弹幕列表
+
+        Returns:
+            是否有问题弹幕
+        """
+        if not danmakus:
+            return False
+
+        self._is_dialog_mode = True
+        self.session.load_data(danmakus)
+        self.run_validation()
+        self.session.mark_head_errors()  # 锁定初始错误快照
+        self.session.set_dirty(False)
+        self.dataChanged.emit()
+        return self.active_error_count > 0
+
     def commit_to_state(self) -> tuple[int, int, int]:
         """将修改结果提交回 AppState，清空沙盒"""
         final_list, fixed, removed = self.session.get_committed_data()
@@ -161,7 +187,8 @@ class EditorController(QObject):
     def run_validation(self):
         """执行校验：自动向沙盒注入最新的校验参数"""
         duration = -1
-        if self.has_video_context:
+        # 弹窗模式下不检查 video_context，直接使用 -1（跳过时间检查）
+        if not self._is_dialog_mode and self.has_video_context:
             duration = self.state.video_state.selected_part_duration_ms
 
         config = self.state.validation_config

--- a/src/danmaku_sender/controller/editor_controller.py
+++ b/src/danmaku_sender/controller/editor_controller.py
@@ -141,13 +141,9 @@ class EditorController(QObject):
         """执行校验：自动向沙盒注入最新的校验参数
 
         如果任务有关联的视频上下文，使用视频时长进行时间越界检查；
-        否则跳过时间检查（duration=-1）。
+        否则跳过时间检查。
         """
-        duration = -1
-        if self.has_video_context:
-            # 使用任务关联的视频时长（从 task.target 获取，可能需要从 API 查询）
-            # 当前先使用 -1 跳过，后续可接入视频时长查询
-            duration = -1
+        duration = self.task.duration_ms if self.task.duration_ms > 0 else -1
 
         config = self.state.validation_config
         self.session.validate(duration_ms=duration, config=config)

--- a/src/danmaku_sender/types/models/queue.py
+++ b/src/danmaku_sender/types/models/queue.py
@@ -32,6 +32,7 @@ class QueueTask:
     p_index: int = 0
     p_title: str = ""
     xml_path: str = ""
+    duration_ms: int = 0  # 视频时长（毫秒），用于弹幕时间越界校验
     status: TaskStatus = TaskStatus.PENDING
     error_msg: str = ""
     attempted: int = 0
@@ -58,5 +59,6 @@ class QueueTask:
         self.danmakus = source.danmakus
         self.total = source.total
         self.xml_path = source.xml_path
+        self.duration_ms = source.duration_ms
         self.status = source.status
         self.config_snapshot = source.config_snapshot

--- a/src/danmaku_sender/ui/editor/__init__.py
+++ b/src/danmaku_sender/ui/editor/__init__.py
@@ -1,4 +1,4 @@
-from .page import EditorPage
+from .dialog import EditorDialog
 
 
-__all__ = ["EditorPage"]
+__all__ = ["EditorDialog"]

--- a/src/danmaku_sender/ui/editor/dialog.py
+++ b/src/danmaku_sender/ui/editor/dialog.py
@@ -19,13 +19,13 @@ from danmaku_sender.types.models.queue import QueueTask
 from danmaku_sender.runtime.state.app_state import AppState
 
 
-class EditorPage(QDialog):
+class EditorDialog(QDialog):
     """编辑器弹窗 - 用于编辑单个任务的弹幕数据"""
 
     def __init__(self, task: QueueTask, state: AppState, parent=None):
         super().__init__(parent)
         self.task = task
-        self.controller = EditorController(state, self)
+        self.controller = EditorController(task, state, self)
         self.logger = logging.getLogger(__name__)
 
         self.current_item_id: str | None = None
@@ -47,8 +47,7 @@ class EditorPage(QDialog):
 
     def _load_task_danmakus(self):
         """加载任务的弹幕数据到编辑器"""
-        if self.task.danmakus:
-            self.controller.load_from_danmakus(self.task.danmakus)
+        if self.controller.load_from_task():
             self._refresh_table()
 
     # region UI Setup & Data Binding
@@ -373,7 +372,8 @@ class EditorPage(QDialog):
         self.current_item_id = None
         self.inspector_group.reset_inspector()
 
-        has_issues = self.controller.load_from_state()
+        # 重新从任务加载弹幕数据并验证
+        has_issues = self.controller.load_from_task()
         if not has_issues:
             QMessageBox.information(self, "验证通过", "所有弹幕均符合当前规范！")
 
@@ -584,11 +584,5 @@ class EditorPage(QDialog):
     def showEvent(self, event):
         super().showEvent(event)
 
-        # 弹窗模式下数据已在 __init__ 中加载，跳过自动检出
-        if not self.controller._is_dialog_mode:
-            # 如果全局状态里有数据 (比如刚在发射器加载了)，但编辑器是空的
-            if self.controller.source_data_exists and not self.controller.has_data:
-                self.logger.info("检测到外部加载了新数据，自动检出到编辑器沙盒并执行基础校验。")
-                self.controller.load_from_state()
-
+        # 数据已在 __init__ 中加载，仅刷新 UI 状态
         self._update_ui_state()

--- a/src/danmaku_sender/ui/editor/dialog.py
+++ b/src/danmaku_sender/ui/editor/dialog.py
@@ -295,10 +295,6 @@ class EditorDialog(QDialog):
             self.preview_mode_cb.setChecked(True)
             self.current_item_id = None
             self.inspector_group.reset_inspector()
-            QMessageBox.information(
-                self, "导入成功",
-                f"成功导入 {count} 条弹幕！\n(当前为无视频上下文模式，已跳过时间越界检查)"
-            )
         else:
             QMessageBox.warning(self, "导入失败", "未从文件中解析出有效的弹幕。")
 

--- a/src/danmaku_sender/ui/editor/page.py
+++ b/src/danmaku_sender/ui/editor/page.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from PySide6.QtCore import Qt, QModelIndex, QPoint, Slot
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
     QTableView, QHeaderView, QAbstractItemView, QMessageBox,
     QMenu, QFrame, QCheckBox, QSplitter, QFileDialog
 )
@@ -15,19 +15,41 @@ from .dialogs import EditDanmakuDialog, TimeOffsetDialog, ArrayGeneratorDialog
 from danmaku_sender.ui.framework.style_loader import SvgIcon
 from danmaku_sender.controller.editor_controller import EditorController
 from danmaku_sender.types.models.editor_types import EditorField, InsertPosition
+from danmaku_sender.types.models.queue import QueueTask
 from danmaku_sender.runtime.state.app_state import AppState
 
 
-class EditorPage(QWidget):
-    def __init__(self, state: AppState):
-        super().__init__()
+class EditorPage(QDialog):
+    """编辑器弹窗 - 用于编辑单个任务的弹幕数据"""
+
+    def __init__(self, task: QueueTask, state: AppState, parent=None):
+        super().__init__(parent)
+        self.task = task
         self.controller = EditorController(state, self)
         self.logger = logging.getLogger(__name__)
 
         self.current_item_id: str | None = None
 
+        self.setWindowTitle(f"编辑弹幕 — {task.target.display_string}")
+        self.setMinimumSize(900, 600)
+        self.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowCloseButtonHint
+            | Qt.WindowType.WindowMinMaxButtonsHint
+        )
+
         self._create_ui()
         self.controller.dataChanged.connect(self._refresh_table)
+
+        # 加载任务的弹幕数据
+        self._load_task_danmakus()
+
+    def _load_task_danmakus(self):
+        """加载任务的弹幕数据到编辑器"""
+        if self.task.danmakus:
+            self.controller.load_from_danmakus(self.task.danmakus)
+            self._refresh_table()
 
     # region UI Setup & Data Binding
     def _create_ui(self):
@@ -41,9 +63,6 @@ class EditorPage(QWidget):
         toolbar_layout.setSpacing(8)
 
         # A: 文件级操作
-        self.btn_new = QPushButton(SvgIcon("note_add.svg"), "新建")
-        self.btn_new.clicked.connect(self._create_new_file)
-
         self.btn_import = QPushButton(SvgIcon("file_open.svg"), "导入 XML")
         self.btn_import.clicked.connect(self._import_xml)
 
@@ -51,7 +70,6 @@ class EditorPage(QWidget):
         self.btn_export.setEnabled(False)
         self.btn_export.clicked.connect(self._export_xml)
 
-        toolbar_layout.addWidget(self.btn_new)
         toolbar_layout.addWidget(self.btn_import)
         toolbar_layout.addWidget(self.btn_export)
 
@@ -149,7 +167,7 @@ class EditorPage(QWidget):
         # --- 底部按钮与状态区 ---
         bottom_layout = QHBoxLayout()
 
-        self.status_label = QLabel("提示: 请先在“发射器”页面加载文件并选择分P。")
+        self.status_label = QLabel('提示: 请先在"发射器"页面加载文件并选择分P。')
         self.status_label.setStyleSheet("color: #7f8c8d;")
         self.status_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
 
@@ -188,7 +206,6 @@ class EditorPage(QWidget):
         """统一状态机控制"""
         ctrl = self.controller
 
-        self.btn_new.setEnabled(True)
         self.btn_import.setEnabled(True)
         self.run_btn.setEnabled(ctrl.source_data_exists)
         self.btn_batch.setEnabled(ctrl.has_data)
@@ -199,7 +216,7 @@ class EditorPage(QWidget):
         # 更新状态提示文本和样式
         # 脏数据
         if ctrl.is_dirty:
-            self.status_label.setText("⚠️ 有未应用的修改！请点击“应用所有修改”按钮。")
+            self.status_label.setText('⚠️ 有未保存的修改！请点击"保存到任务"按钮。')
             self.status_label.setStyleSheet("color: #d35400;")
 
         # 已校验数据
@@ -208,20 +225,19 @@ class EditorPage(QWidget):
             if ctrl.active_error_count > 0:
                 self.status_label.setText(f"❌ 发现 {ctrl.active_error_count} 条问题弹幕，请处理。")
                 self.status_label.setStyleSheet("color: red;")
-            # 没有错误，根据是否有视频上下文显示不同的提示
+            # 没有错误
             else:
-                mode = "(深度校验)" if ctrl.has_video_context else "(无视频关联，跳过时间检查)"
-                self.status_label.setText(f"✅ 验证通过，当前无问题 {mode}。")
+                self.status_label.setText("✅ 验证通过，当前无问题。")
                 self.status_label.setStyleSheet("color: green;")
 
         # 有源数据，待校验
         elif ctrl.source_data_exists:
-            self.status_label.setText("提示: 点击”开始校验”以加载并检查弹幕。")
+            self.status_label.setText('提示: 点击"开始校验"以检查弹幕。')
             self.status_label.setStyleSheet("color: #7f8c8d;")
 
         # 未加载任何数据
         else:
-            self.status_label.setText("提示: 请先在”发射器”页面加载文件，或点击新建。")
+            self.status_label.setText('提示: 请先在"发射器"页面加载文件，或点击新建。')
             self.status_label.setStyleSheet("color: #7f8c8d;")
 
     @Slot()
@@ -250,19 +266,6 @@ class EditorPage(QWidget):
 
     # endregion
     # region Core Workflow (File & Validation)
-
-    @Slot()
-    def _create_new_file(self):
-        if self.controller.is_dirty:
-            reply = QMessageBox.question(self, "放弃修改?", "当前有未应用的修改，新建将丢失这些数据。\n是否继续？", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
-            if reply == QMessageBox.StandardButton.No:
-                return
-
-        self.controller.create_new_workspace()
-        self.preview_mode_cb.setChecked(True)
-        self.current_item_id = None
-        self.inspector_group.reset_inspector()
-        QMessageBox.information(self, "新建成功", "已创建空白工作区，你可以开始创作了！")
 
     @Slot()
     def _import_xml(self):
@@ -349,7 +352,7 @@ class EditorPage(QWidget):
         """运行验证逻辑"""
         # 校验前置条件
         if not self.controller.source_data_exists:
-            QMessageBox.warning(self, "无法验证", "当前工作区为空，请先新建或加载弹幕。")
+            QMessageBox.warning(self, "无法验证", "当前工作区为空，请先导入弹幕。")
             return
 
         # 检查未保存修改
@@ -357,18 +360,11 @@ class EditorPage(QWidget):
             reply = QMessageBox.question(
                 self,
                 "确认",
-                "当前有未应用的修改，重新验证将丢弃这些修改。\n是否继续？",
-                buttons=QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+                "当前有未保存的修改，重新验证将丢弃这些修改。\n是否继续？",
+                buttons=QMessageBox.StandardButton.No | QMessageBox.StandardButton.Yes
             )
             if reply == QMessageBox.StandardButton.No:
                 return
-
-        if not self.controller.has_video_context:
-            QMessageBox.information(
-                self,
-                "降级校验模式",
-                "当前未关联目标视频（无 BVID/分P 信息）。\n\n系统将以【降级模式】执行校验：\n✔️ 检查文本长度、换行符、屏蔽词\n⏭️ 跳过弹幕发送时间是否超出视频总时长的检查"
-            )
 
         # 执行验证
         self.status_label.setText("正在验证...")
@@ -383,18 +379,25 @@ class EditorPage(QWidget):
 
     @Slot()
     def _apply_changes(self):
-        """应用修改"""
+        """保存修改到任务"""
         self.current_item_id = None
         self.inspector_group.reset_inspector()
 
-        total, fixed, deleted = self.controller.commit_to_state()
+        # 获取编辑后的弹幕数据
+        final_list = self.controller.get_working_danmakus()
 
-        self.logger.info(f"修改已应用: 修复 {fixed}, 删除 {deleted}")
+        # 更新任务的弹幕数据
+        self.task.danmakus = final_list
+        self.task.total = len(final_list)
+
+        self.logger.info(f"已保存 {len(final_list)} 条弹幕到任务")
         QMessageBox.information(
             self,
-            "应用成功",
-            f"发送队列已更新！\n\n修复: {fixed} 条\n移除: {deleted} 条\n剩余总数: {total} 条"
+            "保存成功",
+            f"已保存 {len(final_list)} 条弹幕到任务！"
         )
+
+        self.accept()
 
     # endregion
     # region Item Operations (Row Level & Dialogs)
@@ -581,9 +584,11 @@ class EditorPage(QWidget):
     def showEvent(self, event):
         super().showEvent(event)
 
-        # 如果全局状态里有数据 (比如刚在发射器加载了)，但编辑器是空的
-        if self.controller.source_data_exists and not self.controller.has_data:
-            self.logger.info("检测到外部加载了新数据，自动检出到编辑器沙盒并执行基础校验。")
-            self.controller.load_from_state()
+        # 弹窗模式下数据已在 __init__ 中加载，跳过自动检出
+        if not self.controller._is_dialog_mode:
+            # 如果全局状态里有数据 (比如刚在发射器加载了)，但编辑器是空的
+            if self.controller.source_data_exists and not self.controller.has_data:
+                self.logger.info("检测到外部加载了新数据，自动检出到编辑器沙盒并执行基础校验。")
+                self.controller.load_from_state()
 
         self._update_ui_state()

--- a/src/danmaku_sender/ui/main_window.py
+++ b/src/danmaku_sender/ui/main_window.py
@@ -12,7 +12,6 @@ from .framework.style_loader import SvgIcon, load_stylesheet, get_app_icon
 from .sender import SenderPage
 from .settings_page import SettingsPage
 from .monitor_page import MonitorPage
-from .editor import EditorPage
 from .dialogs import AboutDialog, HelpDialog, UpdateDialog
 from .account_manager import AccountDialog
 from .history import HistoryPage
@@ -162,7 +161,6 @@ class MainWindow(QMainWindow):
         """初始化页面并绑定导航"""
         self.page_settings = SettingsPage(self.state)
         self.page_sender = SenderPage(self.state, self.rt.history_manager)
-        self.page_editor = EditorPage(self.state)
         self.page_monitor = MonitorPage(self.state, self.rt.history_manager)
         self.page_history = HistoryPage(self.state, self.rt.history_manager)
 
@@ -170,7 +168,6 @@ class MainWindow(QMainWindow):
         pages = [
             ("全局设置", self.page_settings, "settings.svg"),
             ("弹幕发射器", self.page_sender, "send.svg"),
-            ("弹幕编辑器", self.page_editor, "edit_document.svg"),
             ("弹幕监视器", self.page_monitor, "monitor.svg"),
             ("弹幕历史记录", self.page_history, "history.svg"),
         ]
@@ -279,7 +276,6 @@ class MainWindow(QMainWindow):
         # 页面数据绑定
         self.page_settings.init_bindings()
         self.page_sender.init_bindings()
-        self.page_editor.init_bindings()
         self.page_monitor.init_bindings()
         self.page_history.init_bindings()
 

--- a/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
+++ b/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
@@ -184,6 +184,13 @@ class TaskBuilderDialog(QDialog):
             title=self._video_info.title,
         )
 
+        # 获取视频时长（毫秒）
+        duration_ms = 0
+        for p in self._video_info.parts:
+            if p.cid == cid:
+                duration_ms = p.duration * 1000  # 秒转毫秒
+                break
+
         # 解析弹幕文件（如果选了的话）
         danmakus = []
         xml_path = ""
@@ -204,6 +211,7 @@ class TaskBuilderDialog(QDialog):
             p_index=page,
             p_title=part_title,
             xml_path=xml_path,
+            duration_ms=duration_ms,
         )
 
         # 如果没有弹幕，标记为未配置

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -12,12 +12,10 @@ from .components.queue_table import ProgressBarDelegate, QueueTableModel
 from .components.dialogs.task_builder import TaskBuilderDialog
 from .components.dialogs.task_detail import TaskDetailDialog
 
-from danmaku_sender.ui.editor.dialog import EditorDialog
+from danmaku_sender.ui.editor import EditorDialog
 from danmaku_sender.ui.framework.style_loader import SvgIcon
-from danmaku_sender.controller.sender_controller import SenderController, SenderStatus
+from danmaku_sender.controller.sender_controller import SenderController
 from danmaku_sender.service.danmaku_parser import DanmakuParser
-from danmaku_sender.types.models.video import VideoInfo
-from danmaku_sender.types.models.common import VideoTarget
 from danmaku_sender.types.models.queue import QueueTask, TaskStatus
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.service.sender import SendingContext

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -12,7 +12,7 @@ from .components.queue_table import ProgressBarDelegate, QueueTableModel
 from .components.dialogs.task_builder import TaskBuilderDialog
 from .components.dialogs.task_detail import TaskDetailDialog
 
-from danmaku_sender.ui.editor.page import EditorPage
+from danmaku_sender.ui.editor.dialog import EditorDialog
 from danmaku_sender.ui.framework.style_loader import SvgIcon
 from danmaku_sender.controller.sender_controller import SenderController, SenderStatus
 from danmaku_sender.service.danmaku_parser import DanmakuParser
@@ -242,7 +242,7 @@ class SenderPage(QWidget):
 
     def _edit_danmakus(self, task: QueueTask):
         """编辑任务的弹幕数据（打开编辑器弹窗）"""
-        dialog = EditorPage(task, self.state, self)
+        dialog = EditorDialog(task, self.state, self)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             # 编辑完成后，刷新表格显示
             row = self._queue_model.get_row_by_id(task.task_id)

--- a/src/danmaku_sender/ui/sender/page.py
+++ b/src/danmaku_sender/ui/sender/page.py
@@ -12,6 +12,7 @@ from .components.queue_table import ProgressBarDelegate, QueueTableModel
 from .components.dialogs.task_builder import TaskBuilderDialog
 from .components.dialogs.task_detail import TaskDetailDialog
 
+from danmaku_sender.ui.editor.page import EditorPage
 from danmaku_sender.ui.framework.style_loader import SvgIcon
 from danmaku_sender.controller.sender_controller import SenderController, SenderStatus
 from danmaku_sender.service.danmaku_parser import DanmakuParser
@@ -219,6 +220,7 @@ class SenderPage(QWidget):
         )
 
         menu.addAction("查看详情/编辑配置", lambda: self._show_task_detail(task))  # 所有状态都能查看
+        menu.addAction("编辑弹幕", lambda: self._edit_danmakus(task)).setEnabled(is_editable)
         menu.addSeparator()
         menu.addAction("上移", lambda: self._move_task(task.task_id, -1)).setEnabled(is_editable)
         menu.addAction("下移", lambda: self._move_task(task.task_id, 1)).setEnabled(is_editable)
@@ -237,6 +239,16 @@ class SenderPage(QWidget):
             if row >= 0:
                 self._queue_model.refresh_row(row)
             self.logger.info(f"已更新任务: {task.target.display_string}")
+
+    def _edit_danmakus(self, task: QueueTask):
+        """编辑任务的弹幕数据（打开编辑器弹窗）"""
+        dialog = EditorPage(task, self.state, self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            # 编辑完成后，刷新表格显示
+            row = self._queue_model.get_row_by_id(task.task_id)
+            if row >= 0:
+                self._queue_model.refresh_row(row)
+            self.logger.info(f"已编辑弹幕: {task.target.display_string} ({task.total} 条)")
 
     def _move_task(self, task_id: str, direction: int):
         self.state.queue_state.move_task(task_id, direction)


### PR DESCRIPTION
## Sourcery 摘要

将弹幕编辑器集成为发射器任务的附属弹窗，并让编辑、校验与保存流程直接作用于队列任务。

新功能：
- 将弹幕编辑器改为从发射器任务打开的附属弹窗，支持直接编辑单个任务的弹幕数据。
- 在任务中保存视频时长，用于编辑器执行弹幕时间越界校验。

改进：
- 移除主窗口中的独立弹幕编辑器页面和工作区管理流程，使编辑内容与队列任务保持一致。
- 支持在保存编辑结果后更新任务弹幕数量并关闭编辑弹窗。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将弹幕编辑器集成为发射器任务的附属弹窗，并让编辑、校验与保存流程直接作用于队列任务。

New Features:
- 将弹幕编辑器改为从发射器任务打开的附属弹窗，支持直接编辑单个任务的弹幕数据。
- 在任务中保存视频时长，用于编辑器执行弹幕时间越界校验。

Enhancements:
- 移除主窗口中的独立弹幕编辑器页面和工作区管理流程，使编辑内容与队列任务保持一致。
- 支持在保存编辑结果后更新任务弹幕数量并关闭编辑弹窗。

</details>