### PR TITLE
feat(task_builder): 在未选择弹幕文件的情况下 程序自动添加示例弹幕

### DIFF
--- a/src/danmaku_sender/ui/editor/dialog.py
+++ b/src/danmaku_sender/ui/editor/dialog.py
@@ -236,7 +236,7 @@ class EditorDialog(QDialog):
 
         # 未加载任何数据
         else:
-            self.status_label.setText('提示: 请先在"发射器"页面加载文件，或点击新建。')
+            self.status_label.setText('提示: 请先加载文件。')
             self.status_label.setStyleSheet("color: #7f8c8d;")
 
     @Slot()

--- a/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
+++ b/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
@@ -219,6 +219,7 @@ class TaskBuilderDialog(QDialog):
         # 如果没有弹幕，标记为未配置
         if not danmakus:
             danmakus.append(Danmaku(msg="未选择弹幕文件-示例弹幕", progress=0, mode=Danmaku.Mode.SCROLL))
+            task.total = len(task.danmakus)
             task.status = TaskStatus.UNCONFIGURED
 
         self.taskCreated.emit(task)

--- a/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
+++ b/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtCore import Qt, Signal, Slot
 
 from danmaku_sender.controller.video_controller import VideoController
+from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.video import VideoInfo
 from danmaku_sender.types.models.queue import QueueTask, TaskStatus
 from danmaku_sender.types.models.common import VideoTarget
@@ -14,6 +15,7 @@ from danmaku_sender.config import ApiAuthConfig, SenderConfig
 from danmaku_sender.runtime.state.app_state import AppState
 from danmaku_sender.service.danmaku_parser import DanmakuParser
 from danmaku_sender.utils.string_utils import parse_bilibili_link
+
 
 
 logger = logging.getLogger(__name__)
@@ -216,6 +218,7 @@ class TaskBuilderDialog(QDialog):
 
         # 如果没有弹幕，标记为未配置
         if not danmakus:
+            danmakus.append(Danmaku(msg="未选择弹幕文件-示例弹幕", progress=0, mode=Danmaku.Mode.SCROLL))
             task.status = TaskStatus.UNCONFIGURED
 
         self.taskCreated.emit(task)

--- a/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
+++ b/src/danmaku_sender/ui/sender/components/dialogs/task_builder.py
@@ -220,6 +220,7 @@ class TaskBuilderDialog(QDialog):
         if not danmakus:
             danmakus.append(Danmaku(msg="未选择弹幕文件-示例弹幕", progress=0, mode=Danmaku.Mode.SCROLL))
             task.total = len(task.danmakus)
+            logger.info(f"任务 {target.display_string} 没有弹幕文件，已添加示例弹幕。")
             task.status = TaskStatus.UNCONFIGURED
 
         self.taskCreated.emit(task)


### PR DESCRIPTION
在未选择弹幕文件的情况下，程序自动添加示例弹幕，以便用户手动编辑（如果没有弹幕，右键列表控件没有反应，不会弹出编辑操作菜单）。

## Sourcery 总结

为未配置弹幕的任务提供默认示例弹幕并优化无数据提示。

新功能：
- 在未选择弹幕文件时自动添加可编辑的示例弹幕。

错误修复：
- 确保无弹幕任务仍可通过列表控件进入编辑操作。

改进：
- 简化编辑器在无数据状态下的提示文案。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为未使用弹幕文件创建的任务提供默认可编辑弹幕，并优化空状态提示。

新功能：
- 对于未选择弹幕文件创建的任务，自动添加可编辑的示例弹幕。

错误修复：
- 通过列表编辑操作，确保未配置弹幕的任务仍可访问。

增强功能：
- 简化未加载数据时编辑器中显示的提示信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

为未配置的任务提供可编辑的示例弹幕，并提供更清晰的空状态指引。

新功能：
- 创建任务时，如果未选择弹幕文件，则自动添加可编辑的示例弹幕。

错误修复：
- 通过列表编辑操作，保持未配置弹幕的任务可访问。

改进：
- 简化未加载数据时显示的编辑器消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide unconfigured tasks with editable sample danmaku and clearer empty-state guidance.

New Features:
- Automatically add an editable sample danmaku when creating a task without a selected danmaku file.

Bug Fixes:
- Keep tasks without configured danmaku accessible through list editing actions.

Enhancements:
- Simplify the editor message shown when no data is loaded.

</details>

</details>

</details>