### PR TITLE
refactor(monitor): 分离核销逻辑为 DanmakuVerifier，纯依赖注入tor/danmaku verifier

### DIFF
--- a/src/danmaku_sender/controller/history_controller.py
+++ b/src/danmaku_sender/controller/history_controller.py
@@ -4,8 +4,10 @@ from PySide6.QtCore import QObject, Signal
 
 from .concurrency import PoolTask
 
+from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.service.danmaku_verifier import DanmakuVerifier
+from danmaku_sender.types.models.common import VerifyResult
 from danmaku_sender.config import ApiAuthConfig
 
 
@@ -34,17 +36,39 @@ class HistoryController(QObject):
     def verify_records(self, cid: int, auth_config: ApiAuthConfig):
         """发起异步弹幕验证（单个分P）"""
         PoolTask.submit(
-            DanmakuVerifier.verify_by_cid,
+            self._task_verify_single,
             self.verifyCompleted.emit,
             self.errorOccurred.emit,
-            cid, auth_config, self.history_manager,
+            cid, auth_config,
         )
 
     def verify_all(self, auth_config: ApiAuthConfig):
         """发起异步批量验证（所有待验证记录）"""
         PoolTask.submit(
-            DanmakuVerifier.verify_all_pending,
+            self._task_verify_all,
             self.verifyCompleted.emit,
             self.errorOccurred.emit,
-            auth_config, self.history_manager,
+            auth_config,
         )
+
+    # ---- 后台任务：装配与执行逻辑 ----
+
+    def _task_verify_single(self, cid: int, auth_config: ApiAuthConfig) -> VerifyResult:
+        """单个分P验证（后台线程执行）"""
+        with BiliApiClient.from_config(auth_config) as client:
+            verifier = DanmakuVerifier(api_client=client, history_manager=self.history_manager)
+            return verifier.verify_cid(cid)
+
+    def _task_verify_all(self, auth_config: ApiAuthConfig) -> VerifyResult:
+        """批量验证所有待验证记录（后台线程执行）"""
+        pending_cids = self.history_manager.get_pending_cids()
+
+        if not pending_cids:
+            logger.info("没有待验证的弹幕记录。")
+            return {'verified': 0, 'lost': 0, 'total_checked': 0}
+
+        cids = [entry['cid'] for entry in pending_cids]
+
+        with BiliApiClient.from_config(auth_config) as client:
+            verifier = DanmakuVerifier(api_client=client, history_manager=self.history_manager)
+            return verifier.verify_batch(cids)

--- a/src/danmaku_sender/controller/history_controller.py
+++ b/src/danmaku_sender/controller/history_controller.py
@@ -5,7 +5,7 @@ from PySide6.QtCore import QObject, Signal
 from .concurrency import PoolTask
 
 from danmaku_sender.repo.history_manager import HistoryManager
-from danmaku_sender.service.bili_monitor import BiliDanmakuMonitor
+from danmaku_sender.service.danmaku_verifier import DanmakuVerifier
 from danmaku_sender.config import ApiAuthConfig
 
 
@@ -34,7 +34,7 @@ class HistoryController(QObject):
     def verify_records(self, cid: int, auth_config: ApiAuthConfig):
         """发起异步弹幕验证（单个分P）"""
         PoolTask.submit(
-            BiliDanmakuMonitor.verify_by_cid,
+            DanmakuVerifier.verify_by_cid,
             self.verifyCompleted.emit,
             self.errorOccurred.emit,
             cid, auth_config, self.history_manager,
@@ -43,7 +43,7 @@ class HistoryController(QObject):
     def verify_all(self, auth_config: ApiAuthConfig):
         """发起异步批量验证（所有待验证记录）"""
         PoolTask.submit(
-            BiliDanmakuMonitor.verify_all_pending,
+            DanmakuVerifier.verify_all_pending,
             self.verifyCompleted.emit,
             self.errorOccurred.emit,
             auth_config, self.history_manager,

--- a/src/danmaku_sender/controller/monitor_controller.py
+++ b/src/danmaku_sender/controller/monitor_controller.py
@@ -6,10 +6,12 @@ from PySide6.QtCore import QObject, Signal, Slot
 from .concurrency import WorkerThread
 from .system_utils import KeepSystemAwake
 
+from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.types.models.common import VideoTarget
 from danmaku_sender.config import ApiAuthConfig, MonitorConfig
 from danmaku_sender.service.bili_monitor import BiliDanmakuMonitor
+from danmaku_sender.service.danmaku_verifier import DanmakuVerifier
 
 
 logger = logging.getLogger(__name__)
@@ -112,8 +114,12 @@ class MonitorTaskWorker(WorkerThread):
     def _run_monitor_loop(self):
         with (
             KeepSystemAwake(self.monitor_config.prevent_sleep),
-            BiliDanmakuMonitor.create(self.target, self.auth_config, self.history_manager) as monitor
+            BiliApiClient.from_config(self.auth_config) as client
         ):
+            # 由 Worker 管理 BiliApiClient 生命周期，注入给 Monitor
+            verifier = DanmakuVerifier(api_client=client, history_manager=self.history_manager)
+            monitor = BiliDanmakuMonitor(verifier=verifier, target=self.target, history_manager=self.history_manager)
+
             self.logger.info(f"🛡️ 监视启动: {self.target.display_string} | CID: {self.target.cid}")
 
             while not self.stop_event.is_set():

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -1,38 +1,72 @@
+"""弹幕监视器 - 负责持续盯住某个 Target 并出统计指标"""
+
 import logging
 from contextlib import contextmanager
 
+from .danmaku_verifier import DanmakuVerifier
 from .danmaku_parser import DanmakuParser
 
 from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.types.exceptions.exceptions import BiliApiError, BiliNetworkError
 from danmaku_sender.repo.history_manager import HistoryManager
-from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import VideoTarget, MonitorStats, VerifyResult
 from danmaku_sender.config import ApiAuthConfig
 
 
+logger = logging.getLogger(__name__)
+
+
 class BiliDanmakuMonitor:
     """
-    弹幕监视核心引擎
+    弹幕监视器
 
-    负责执行单次的网络请求与数据库比对。
-    通过 context manager 工厂创建，自动管理 BiliApiClient 生命周期。
+    负责针对特定 VideoTarget 的持续监视周期管理。
+    内部使用 DanmakuVerifier 执行核销操作。
     """
 
-    def __init__(self, api_client: BiliApiClient, target: VideoTarget, history_manager: HistoryManager):
-        self.api_client = api_client
+    def __init__(self, verifier: DanmakuVerifier, target: VideoTarget, history_manager: HistoryManager):
+        self.verifier = verifier
         self.target = target
-
-        self.danmaku_parser = DanmakuParser()
         self.history_manager = history_manager
-        self.logger = logging.getLogger(__name__)
 
     @staticmethod
     @contextmanager
     def create(target: VideoTarget, auth_config: ApiAuthConfig, history_manager: HistoryManager):
         """Context manager 工厂：自动管理 client 生命周期"""
         with BiliApiClient.from_config(auth_config) as client:
-            yield BiliDanmakuMonitor(api_client=client, target=target, history_manager=history_manager)
+            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
+            yield BiliDanmakuMonitor(verifier=verifier, target=target, history_manager=history_manager)
+
+    def monitor(self, stats_baseline: float = 0.0) -> MonitorStats:
+        """
+        执行单次核销与统计。
+
+        Args:
+            stats_baseline: 统计基线时间（秒），用于过滤历史数据
+
+        Returns:
+            MonitorStats: {'total': int, 'verified': int, 'pending': int, 'lost': int}
+
+        Raises:
+            BiliApiError: API 请求失败
+            BiliNetworkError: 网络连接失败
+        """
+        # 使用 verifier 执行核销
+        verify_result = self.verifier.verify_cid(self.target.cid, mark_lost=True)
+
+        if verify_result['verified'] > 0:
+            logger.info(f"✨ 核销成功: 确认了 {verify_result['verified']} 条新存活弹幕。")
+
+        # 获取统计数据
+        total, verified, lost = self.history_manager.get_stats(self.target.cid, stats_baseline)
+        pending = max(0, total - verified - lost)
+
+        return {
+            'total': total,
+            'verified': verified,
+            'pending': pending,
+            'lost': lost
+        }
 
     @classmethod
     def verify_by_cid(cls, cid: int, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
@@ -43,7 +77,8 @@ class BiliDanmakuMonitor:
             VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
         """
         with BiliApiClient.from_config(auth_config) as client:
-            return cls._verify_cid_with_client(cid, client, history_manager)
+            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
+            return verifier.verify_cid(cid)
 
     @classmethod
     def verify_all_pending(cls, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
@@ -53,103 +88,14 @@ class BiliDanmakuMonitor:
         Returns:
             VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
         """
-        logger = logging.getLogger(__name__)
         pending_cids = history_manager.get_pending_cids()
 
         if not pending_cids:
             logger.info("没有待验证的弹幕记录。")
             return {'verified': 0, 'lost': 0, 'total_checked': 0}
 
-        logger.info(f"开始批量验证，共 {len(pending_cids)} 个 CID 待检查。")
-
-        total_verified = 0
-        total_lost = 0
-        total_checked = 0
+        cids = [entry['cid'] for entry in pending_cids]
 
         with BiliApiClient.from_config(auth_config) as client:
-            for entry in pending_cids:
-                cid = entry['cid']
-                try:
-                    result = cls._verify_cid_with_client(cid, client, history_manager)
-                    total_verified += result['verified']
-                    total_lost += result['lost']
-                    total_checked += result['total_checked']
-                except Exception as e:
-                    logger.warning(f"CID {cid} 验证失败，跳过: {e}")
-
-        logger.info(f"批量验证完成: 共核销 {total_verified} 条，标记丢失 {total_lost} 条，检查 {len(pending_cids)} 个 CID，{total_checked} 条在线弹幕。")
-
-        return {
-            'verified': total_verified,
-            'lost': total_lost,
-            'total_checked': total_checked,
-        }
-
-    @classmethod
-    def _verify_cid_with_client(cls, cid: int, client: BiliApiClient, history_manager: HistoryManager) -> VerifyResult:
-        """使用已有的 client 验证单个 CID（避免重复创建连接）"""
-        logger = logging.getLogger(__name__)
-        parser = DanmakuParser()
-
-        try:
-            xml_content = client.get_danmaku_list_xml(cid)
-            online_danmakus = parser.parse_xml_content(xml_content, is_online=True)
-        except (BiliApiError, BiliNetworkError) as e:
-            logger.warning(f"获取在线弹幕失败: {e}")
-            raise
-        except Exception as e:
-            logger.error(f"解析在线弹幕内容时发生错误: {e}")
-            raise
-
-        online_dmids = [dm.dmid for dm in online_danmakus if dm.dmid]
-
-        verified_count = 0
-        if online_dmids:
-            verified_count = history_manager.verify_dmids(online_dmids)
-
-        lost_count = history_manager.mark_as_lost(cid, online_dmids)
-
-        logger.info(f"[CID:{cid}] 验证完成: 核销 {verified_count} 条，标记丢失 {lost_count} 条，共检查 {len(online_dmids)} 条在线弹幕。")
-
-        return {
-            'verified': verified_count,
-            'lost': lost_count,
-            'total_checked': len(online_dmids),
-        }
-
-    def _fetch_online_danmakus(self) -> list[Danmaku]:
-        """获取在线弹幕列表"""
-        try:
-            xml_content = self.api_client.get_danmaku_list_xml(self.target.cid)
-            return self.danmaku_parser.parse_xml_content(xml_content, is_online=True)
-
-        except (BiliApiError, BiliNetworkError) as e:
-            self.logger.warning(f"获取在线弹幕失败: {e.message}")
-            return []
-
-        except Exception as e:
-            self.logger.error(f"解析在线弹幕内容时发生错误: {e}")
-            return []
-
-    def monitor(self, stats_baseline: float = 0.0) -> MonitorStats:
-        """执行单次核销与统计"""
-        # 提取与核销
-        online_danmakus = self._fetch_online_danmakus()
-        online_dmids = [dm.dmid for dm in online_danmakus if dm.dmid]
-
-        if online_dmids:
-            verified_count = self.history_manager.verify_dmids(online_dmids)
-            if verified_count > 0:
-                self.logger.info(f"✨ 核销成功: 确认了 {verified_count} 条新存活弹幕。")
-
-        # 传入基准时间，获取过滤后的数据
-        total, verified, lost = self.history_manager.get_stats(self.target.cid, stats_baseline)
-
-        pending = max(0, total - verified - lost)
-
-        return {
-            'total': total,
-            'verified': verified,
-            'pending': pending,
-            'lost': lost
-        }
+            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
+            return verifier.verify_batch(cids)

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -1,15 +1,11 @@
 """弹幕监视器 - 负责持续盯住某个 Target 并出统计指标"""
 
 import logging
-from contextlib import contextmanager
-from typing import Callable
 
 from .danmaku_verifier import DanmakuVerifier
 
-from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.repo.history_manager import HistoryManager
-from danmaku_sender.types.models.common import VideoTarget, MonitorStats, VerifyResult
-from danmaku_sender.config import ApiAuthConfig
+from danmaku_sender.types.models.common import VideoTarget, MonitorStats
 
 
 logger = logging.getLogger(__name__)
@@ -21,20 +17,14 @@ class BiliDanmakuMonitor:
 
     负责针对特定 VideoTarget 的持续监视周期管理。
     内部使用 DanmakuVerifier 执行核销操作。
+
+    纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
     """
 
     def __init__(self, verifier: DanmakuVerifier, target: VideoTarget, history_manager: HistoryManager):
         self.verifier = verifier
         self.target = target
         self.history_manager = history_manager
-
-    @staticmethod
-    @contextmanager
-    def create(target: VideoTarget, auth_config: ApiAuthConfig, history_manager: HistoryManager):
-        """Context manager 工厂：自动管理 client 生命周期"""
-        with BiliApiClient.from_config(auth_config) as client:
-            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
-            yield BiliDanmakuMonitor(verifier=verifier, target=target, history_manager=history_manager)
 
     def monitor(self, stats_baseline: float = 0.0) -> MonitorStats:
         """
@@ -69,43 +59,3 @@ class BiliDanmakuMonitor:
             'pending': pending,
             'lost': lost
         }
-
-    @classmethod
-    def verify_by_cid(cls, cid: int, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
-        """
-        轻量级单次验证：拉取指定 CID 的在线弹幕，核销存活并标记丢失。
-
-        Returns:
-            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
-        """
-        with BiliApiClient.from_config(auth_config) as client:
-            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
-            return verifier.verify_cid(cid)
-
-    @classmethod
-    def verify_all_pending(
-        cls,
-        auth_config: ApiAuthConfig,
-        history_manager: HistoryManager,
-        on_progress: Callable[[int, int, VerifyResult], None] | None = None
-    ) -> VerifyResult:
-        """
-        批量验证所有含有待验证弹幕的 CID。
-
-        Args:
-            on_progress: 进度回调 (已处理数, 总数, 本次增量结果)
-
-        Returns:
-            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
-        """
-        pending_cids = history_manager.get_pending_cids()
-
-        if not pending_cids:
-            logger.info("没有待验证的弹幕记录。")
-            return {'verified': 0, 'lost': 0, 'total_checked': 0}
-
-        cids = [entry['cid'] for entry in pending_cids]
-
-        with BiliApiClient.from_config(auth_config) as client:
-            verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
-            return verifier.verify_batch(cids, on_progress=on_progress)

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -33,23 +33,24 @@ class BiliDanmakuMonitor:
         注意：监视过程中不标记丢失（mark_lost=False），因为发送队列可能还在进行中，
         B站弹幕分发有延迟，刚发送的弹幕可能还未进入弹幕池。丢失标记应由用户在历史记录页统一清算。
 
+        网络/解析异常会被捕获并记录日志，不会中断监视循环。
+
         Args:
             stats_baseline: 统计基线时间（秒），用于过滤历史数据
 
         Returns:
             MonitorStats: {'total': int, 'verified': int, 'pending': int, 'lost': int}
-
-        Raises:
-            BiliApiError: API 请求失败
-            BiliNetworkError: 网络连接失败
         """
         # 使用 verifier 执行核销（不标记丢失，避免误杀刚发送的弹幕）
-        verify_result = self.verifier.verify_cid(self.target.cid, mark_lost=False)
+        try:
+            verify_result = self.verifier.verify_cid(self.target.cid, mark_lost=False)
+            if verify_result['verified'] > 0:
+                logger.info(f"✨ 核销成功: 确认了 {verify_result['verified']} 条新存活弹幕。")
+        except Exception as e:
+            # 网络/解析异常不中断监视循环，仅记录日志
+            logger.warning(f"本轮核销失败，继续监视: {e}")
 
-        if verify_result['verified'] > 0:
-            logger.info(f"✨ 核销成功: 确认了 {verify_result['verified']} 条新存活弹幕。")
-
-        # 获取统计数据
+        # 获取统计数据（即使核销失败也要统计）
         total, verified, lost = self.history_manager.get_stats(self.target.cid, stats_baseline)
         pending = max(0, total - verified - lost)
 

--- a/src/danmaku_sender/service/bili_monitor.py
+++ b/src/danmaku_sender/service/bili_monitor.py
@@ -2,12 +2,11 @@
 
 import logging
 from contextlib import contextmanager
+from typing import Callable
 
 from .danmaku_verifier import DanmakuVerifier
-from .danmaku_parser import DanmakuParser
 
 from danmaku_sender.repo.bili_api_client import BiliApiClient
-from danmaku_sender.types.exceptions.exceptions import BiliApiError, BiliNetworkError
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.types.models.common import VideoTarget, MonitorStats, VerifyResult
 from danmaku_sender.config import ApiAuthConfig
@@ -41,6 +40,9 @@ class BiliDanmakuMonitor:
         """
         执行单次核销与统计。
 
+        注意：监视过程中不标记丢失（mark_lost=False），因为发送队列可能还在进行中，
+        B站弹幕分发有延迟，刚发送的弹幕可能还未进入弹幕池。丢失标记应由用户在历史记录页统一清算。
+
         Args:
             stats_baseline: 统计基线时间（秒），用于过滤历史数据
 
@@ -51,8 +53,8 @@ class BiliDanmakuMonitor:
             BiliApiError: API 请求失败
             BiliNetworkError: 网络连接失败
         """
-        # 使用 verifier 执行核销
-        verify_result = self.verifier.verify_cid(self.target.cid, mark_lost=True)
+        # 使用 verifier 执行核销（不标记丢失，避免误杀刚发送的弹幕）
+        verify_result = self.verifier.verify_cid(self.target.cid, mark_lost=False)
 
         if verify_result['verified'] > 0:
             logger.info(f"✨ 核销成功: 确认了 {verify_result['verified']} 条新存活弹幕。")
@@ -81,9 +83,17 @@ class BiliDanmakuMonitor:
             return verifier.verify_cid(cid)
 
     @classmethod
-    def verify_all_pending(cls, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
+    def verify_all_pending(
+        cls,
+        auth_config: ApiAuthConfig,
+        history_manager: HistoryManager,
+        on_progress: Callable[[int, int, VerifyResult], None] | None = None
+    ) -> VerifyResult:
         """
         批量验证所有含有待验证弹幕的 CID。
+
+        Args:
+            on_progress: 进度回调 (已处理数, 总数, 本次增量结果)
 
         Returns:
             VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
@@ -98,4 +108,4 @@ class BiliDanmakuMonitor:
 
         with BiliApiClient.from_config(auth_config) as client:
             verifier = DanmakuVerifier(api_client=client, history_manager=history_manager)
-            return verifier.verify_batch(cids)
+            return verifier.verify_batch(cids, on_progress=on_progress)

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -1,6 +1,7 @@
 """弹幕核验服务 - 负责查在线、对库、标状态"""
 
 import logging
+from contextlib import contextmanager
 from typing import Callable
 
 from .danmaku_parser import DanmakuParser
@@ -10,6 +11,7 @@ from danmaku_sender.types.exceptions.exceptions import BiliApiError, BiliNetwork
 from danmaku_sender.repo.history_manager import HistoryManager
 from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import VerifyResult
+from danmaku_sender.config import ApiAuthConfig
 
 
 logger = logging.getLogger(__name__)
@@ -143,3 +145,48 @@ class DanmakuVerifier:
         except Exception as e:
             logger.error(f"[CID:{cid}] 解析在线弹幕内容时发生错误: {e}")
             raise
+
+    @classmethod
+    @contextmanager
+    def create(cls, auth_config: ApiAuthConfig, history_manager: HistoryManager):
+        """Context manager 工厂：自动管理 client 生命周期"""
+        with BiliApiClient.from_config(auth_config) as client:
+            yield cls(api_client=client, history_manager=history_manager)
+
+    @classmethod
+    def verify_by_cid(cls, cid: int, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
+        """
+        轻量级单次验证：拉取指定 CID 的在线弹幕，核销存活并标记丢失。
+
+        Returns:
+            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
+        """
+        with cls.create(auth_config, history_manager) as verifier:
+            return verifier.verify_cid(cid)
+
+    @classmethod
+    def verify_all_pending(
+        cls,
+        auth_config: ApiAuthConfig,
+        history_manager: HistoryManager,
+        on_progress: Callable[[int, int, VerifyResult], None] | None = None
+    ) -> VerifyResult:
+        """
+        批量验证所有含有待验证弹幕的 CID。
+
+        Args:
+            on_progress: 进度回调 (已处理数, 总数, 本次增量结果)
+
+        Returns:
+            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
+        """
+        pending_cids = history_manager.get_pending_cids()
+
+        if not pending_cids:
+            logger.info("没有待验证的弹幕记录。")
+            return {'verified': 0, 'lost': 0, 'total_checked': 0}
+
+        cids = [entry['cid'] for entry in pending_cids]
+
+        with cls.create(auth_config, history_manager) as verifier:
+            return verifier.verify_batch(cids, on_progress=on_progress)

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -1,7 +1,6 @@
 """弹幕核验服务 - 负责查在线、对库、标状态"""
 
 import logging
-from contextlib import contextmanager
 from typing import Callable
 
 from .danmaku_parser import DanmakuParser
@@ -9,9 +8,7 @@ from .danmaku_parser import DanmakuParser
 from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.types.exceptions.exceptions import BiliApiError, BiliNetworkError
 from danmaku_sender.repo.history_manager import HistoryManager
-from danmaku_sender.types.models.danmaku import Danmaku
 from danmaku_sender.types.models.common import VerifyResult
-from danmaku_sender.config import ApiAuthConfig
 
 
 logger = logging.getLogger(__name__)
@@ -145,48 +142,3 @@ class DanmakuVerifier:
         except Exception as e:
             logger.error(f"[CID:{cid}] 解析在线弹幕内容时发生错误: {e}")
             raise
-
-    @classmethod
-    @contextmanager
-    def create(cls, auth_config: ApiAuthConfig, history_manager: HistoryManager):
-        """Context manager 工厂：自动管理 client 生命周期"""
-        with BiliApiClient.from_config(auth_config) as client:
-            yield cls(api_client=client, history_manager=history_manager)
-
-    @classmethod
-    def verify_by_cid(cls, cid: int, auth_config: ApiAuthConfig, history_manager: HistoryManager) -> VerifyResult:
-        """
-        轻量级单次验证：拉取指定 CID 的在线弹幕，核销存活并标记丢失。
-
-        Returns:
-            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
-        """
-        with cls.create(auth_config, history_manager) as verifier:
-            return verifier.verify_cid(cid)
-
-    @classmethod
-    def verify_all_pending(
-        cls,
-        auth_config: ApiAuthConfig,
-        history_manager: HistoryManager,
-        on_progress: Callable[[int, int, VerifyResult], None] | None = None
-    ) -> VerifyResult:
-        """
-        批量验证所有含有待验证弹幕的 CID。
-
-        Args:
-            on_progress: 进度回调 (已处理数, 总数, 本次增量结果)
-
-        Returns:
-            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
-        """
-        pending_cids = history_manager.get_pending_cids()
-
-        if not pending_cids:
-            logger.info("没有待验证的弹幕记录。")
-            return {'verified': 0, 'lost': 0, 'total_checked': 0}
-
-        cids = [entry['cid'] for entry in pending_cids]
-
-        with cls.create(auth_config, history_manager) as verifier:
-            return verifier.verify_batch(cids, on_progress=on_progress)

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -106,9 +106,12 @@ class DanmakuVerifier:
                 logger.warning(f"CID {cid} 验证失败，跳过: {e}")
                 result: VerifyResult = {'verified': 0, 'lost': 0, 'total_checked': 0}
 
-            # 进度回调（无论成功失败都调用）
+            # 进度回调（无论成功失败都调用，回调异常不中断批处理）
             if on_progress:
-                on_progress(i + 1, len(cids), result)
+                try:
+                    on_progress(i + 1, len(cids), result)
+                except Exception as e:
+                    logger.warning(f"进度回调执行失败，继续处理: {e}")
 
         logger.info(f"批量验证完成: 共核销 {total_verified} 条，标记丢失 {total_lost} 条，检查 {len(cids)} 个 CID，{total_checked} 条在线弹幕。")
 

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -1,0 +1,145 @@
+"""弹幕核验服务 - 负责查在线、对库、标状态"""
+
+import logging
+from typing import Callable
+
+from .danmaku_parser import DanmakuParser
+
+from danmaku_sender.repo.bili_api_client import BiliApiClient
+from danmaku_sender.types.exceptions.exceptions import BiliApiError, BiliNetworkError
+from danmaku_sender.repo.history_manager import HistoryManager
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.common import VerifyResult
+
+
+logger = logging.getLogger(__name__)
+
+
+class DanmakuVerifier:
+    """
+    弹幕核验服务
+
+    负责针对给定的 cid / dmids 执行拉取、比对、落库核销与标记丢失。
+    无状态设计，每次操作都是独立的。
+    """
+
+    def __init__(self, api_client: BiliApiClient, history_manager: HistoryManager):
+        self.api_client = api_client
+        self.history_manager = history_manager
+        self.parser = DanmakuParser()
+
+    def verify_cid(self, cid: int, mark_lost: bool = True) -> VerifyResult:
+        """
+        验证单个 CID：拉取在线弹幕，核销存活并标记丢失。
+
+        Args:
+            cid: 视频分P的 CID
+            mark_lost: 是否标记丢失（默认 True）
+
+        Returns:
+            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
+
+        Raises:
+            BiliApiError: API 请求失败
+            BiliNetworkError: 网络连接失败
+        """
+        try:
+            xml_content = self.api_client.get_danmaku_list_xml(cid)
+            online_danmakus = self.parser.parse_xml_content(xml_content, is_online=True)
+        except (BiliApiError, BiliNetworkError) as e:
+            logger.warning(f"[CID:{cid}] 获取在线弹幕失败: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"[CID:{cid}] 解析在线弹幕内容时发生错误: {e}")
+            raise
+
+        online_dmids = [dm.dmid for dm in online_danmakus if dm.dmid]
+
+        verified_count = 0
+        if online_dmids:
+            verified_count = self.history_manager.verify_dmids(online_dmids)
+
+        lost_count = 0
+        if mark_lost:
+            lost_count = self.history_manager.mark_as_lost(cid, online_dmids)
+
+        logger.info(f"[CID:{cid}] 验证完成: 核销 {verified_count} 条，标记丢失 {lost_count} 条，共检查 {len(online_dmids)} 条在线弹幕。")
+
+        return {
+            'verified': verified_count,
+            'lost': lost_count,
+            'total_checked': len(online_dmids),
+        }
+
+    def verify_batch(
+        self,
+        cids: list[int],
+        mark_lost: bool = True,
+        on_progress: Callable[[int, int, VerifyResult], None] | None = None
+    ) -> VerifyResult:
+        """
+        批量验证多个 CID。
+
+        Args:
+            cids: CID 列表
+            mark_lost: 是否标记丢失（默认 True）
+            on_progress: 进度回调 (已处理数, 总数, 本次增量结果)
+
+        Returns:
+            VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
+        """
+        if not cids:
+            return {'verified': 0, 'lost': 0, 'total_checked': 0}
+
+        logger.info(f"开始批量验证，共 {len(cids)} 个 CID 待检查。")
+
+        total_verified = 0
+        total_lost = 0
+        total_checked = 0
+
+        for i, cid in enumerate(cids):
+            try:
+                result = self.verify_cid(cid, mark_lost=mark_lost)
+                total_verified += result['verified']
+                total_lost += result['lost']
+                total_checked += result['total_checked']
+
+                # 进度回调
+                if on_progress:
+                    on_progress(i + 1, len(cids), result)
+
+            except Exception as e:
+                logger.warning(f"CID {cid} 验证失败，跳过: {e}")
+
+        logger.info(f"批量验证完成: 共核销 {total_verified} 条，标记丢失 {total_lost} 条，检查 {len(cids)} 个 CID，{total_checked} 条在线弹幕。")
+
+        return {
+            'verified': total_verified,
+            'lost': total_lost,
+            'total_checked': total_checked,
+        }
+
+    def get_online_dmids(self, cid: int) -> list[str]:
+        """
+        获取指定 CID 的在线弹幕 DMID 列表（不执行核销）。
+
+        Args:
+            cid: 视频分P的 CID
+
+        Returns:
+            list[str]: 在线弹幕的 DMID 列表
+
+        Raises:
+            BiliApiError: API 请求失败
+            BiliNetworkError: 网络连接失败
+        """
+        try:
+            xml_content = self.api_client.get_danmaku_list_xml(cid)
+            online_danmakus = self.parser.parse_xml_content(xml_content, is_online=True)
+            return [dm.dmid for dm in online_danmakus if dm.dmid]
+        except (BiliApiError, BiliNetworkError) as e:
+            logger.warning(f"[CID:{cid}] 获取在线弹幕失败: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"[CID:{cid}] 解析在线弹幕内容时发生错误: {e}")
+            raise

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -102,13 +102,13 @@ class DanmakuVerifier:
                 total_verified += result['verified']
                 total_lost += result['lost']
                 total_checked += result['total_checked']
-
-                # 进度回调
-                if on_progress:
-                    on_progress(i + 1, len(cids), result)
-
             except Exception as e:
                 logger.warning(f"CID {cid} 验证失败，跳过: {e}")
+                result: VerifyResult = {'verified': 0, 'lost': 0, 'total_checked': 0}
+
+            # 进度回调（无论成功失败都调用）
+            if on_progress:
+                on_progress(i + 1, len(cids), result)
 
         logger.info(f"批量验证完成: 共核销 {total_verified} 条，标记丢失 {total_lost} 条，检查 {len(cids)} 个 CID，{total_checked} 条在线弹幕。")
 

--- a/src/danmaku_sender/service/danmaku_verifier.py
+++ b/src/danmaku_sender/service/danmaku_verifier.py
@@ -32,15 +32,16 @@ class DanmakuVerifier:
         验证单个 CID：拉取在线弹幕，核销存活并标记丢失。
 
         Args:
-            cid: 视频分P的 CID
+            cid: 视频分P 的 CID
             mark_lost: 是否标记丢失（默认 True）
 
         Returns:
             VerifyResult: {'verified': int, 'lost': int, 'total_checked': int}
 
         Raises:
-            BiliApiError: API 请求失败
+            BiliApiError: API 请求失败（业务错误）
             BiliNetworkError: 网络连接失败
+            Exception: XML 解析或其他意外错误
         """
         try:
             xml_content = self.api_client.get_danmaku_list_xml(cid)
@@ -126,14 +127,15 @@ class DanmakuVerifier:
         获取指定 CID 的在线弹幕 DMID 列表（不执行核销）。
 
         Args:
-            cid: 视频分P的 CID
+            cid: 视频分P 的 CID
 
         Returns:
             list[str]: 在线弹幕的 DMID 列表
 
         Raises:
-            BiliApiError: API 请求失败
+            BiliApiError: API 请求失败（业务错误）
             BiliNetworkError: 网络连接失败
+            Exception: XML 解析或其他意外错误
         """
         try:
             xml_content = self.api_client.get_danmaku_list_xml(cid)


### PR DESCRIPTION
## Sourcery 总结

将弹幕核销逻辑拆分为可注入的 DanmakuVerifier，并调整监视与历史核验流程以复用该服务。

新功能：
- 引入独立的弹幕核验服务，支持单 CID、批量核验、在线弹幕查询及可选进度回调。

错误修复：
- 避免监视过程中将因分发延迟暂未出现的弹幕误标记为丢失。

改进：
- 将监视器精简为持续监视与统计职责，并通过依赖注入使用核验服务。
- 统一由控制器装配并管理 Bili API 客户端生命周期，复用客户端执行后台核验任务。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将弹幕核销逻辑提取为可注入的 DanmakuVerifier，并统一监视与历史核验流程中的服务复用。

新功能：
- 引入可复用的弹幕核验服务，支持单个 CID、批量核验及在线弹幕查询，并提供批量进度回调。

错误修复：
- 避免监视期间因弹幕分发延迟，将尚未出现的弹幕误标记为丢失。

改进：
- 精简弹幕监视器的职责，通过依赖注入复用核验服务。
- 统一由控制器管理 Bili API 客户端的生命周期，并在监视和后台历史核验任务中复用。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将弹幕验证提取为可注入服务，并在监控和历史验证工作流中复用该服务。

新功能：
- 引入可复用的 `DanmakuVerifier` 服务，支持单 CID 和批量验证、在线弹幕查询以及进度报告。

Bug 修复：
- 防止监控在延迟分发导致弹幕尚未在线可用时，将最近发送的弹幕标记为丢失。

改进：
- 让 `BiliDanmakuMonitor` 专注于监控和统计，同时注入验证服务。
- 在控制器中集中管理 Bili API 客户端的生命周期，并在监控任务和后台验证任务之间复用客户端。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将弹幕验证提取为可注入的服务，并在监控和历史验证工作流中复用。

新功能：
- 引入可复用的 DanmakuVerifier 服务，支持单个 CID 和批量验证、在线弹幕查询以及进度回调。

Bug 修复：
- 防止监控功能在延迟分发使弹幕上线前，将最近发送的弹幕标记为丢失。

增强功能：
- 让 BiliDanmakuMonitor 专注于监控和统计，同时注入验证服务。
- 集中管理 Bili API 客户端的生命周期，并在监控任务和后台验证任务之间复用客户端。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将弹幕验证提取为可注入服务，并在监控和历史记录验证工作流中复用。

新功能：
- 引入可复用的 `DanmakuVerifier` 服务，支持单 CID 和批量验证、在线弹幕查询以及进度报告。

错误修复：
- 防止监控功能在延迟分发导致弹幕尚未在线可用时，将最近发送的弹幕误标记为丢失。

增强：
- 让 `BiliDanmakuMonitor` 专注于监控和统计，同时注入验证服务。
- 在控制器中集中管理 Bili API 客户端的生命周期，并在监控和验证工作流之间复用客户端。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将弹幕验证提取为可注入服务，并在监控和历史验证工作流中复用。

新功能：
- 添加可复用的 `DanmakuVerifier` 服务，支持单个 CID 和批量验证、在线获取 DMID，以及进度回调。

Bug 修复：
- 防止监控将最近已发送但尚未分发的弹幕标记为丢失。

改进：
- 让 `BiliDanmakuMonitor` 专注于监控和统计，同时注入验证行为。
- 集中管理 Bili API 客户端的生命周期，并在监控和后台验证任务之间复用客户端。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将弹幕验证提取为可注入服务，并在监控和历史验证工作流中复用。

新功能：
- 引入可复用的 DanmakuVerifier 服务，支持单个 CID 和批量验证、在线弹幕查询以及进度回调。

错误修复：
- 防止监控在延迟分发导致弹幕尚未在线可用之前，将最近发送的弹幕标记为丢失。

增强功能：
- 让 BiliDanmakuMonitor 专注于监控和统计，同时注入验证服务。
- 集中管理 Bili API 客户端的生命周期，并在监控和后台验证工作流之间复用客户端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract danmaku verification into an injectable service and reuse it across monitoring and history verification workflows.

New Features:
- Introduce a reusable DanmakuVerifier service for single-CID and batch verification, online danmaku lookup, and progress callbacks.

Bug Fixes:
- Prevent monitoring from marking recently sent danmaku as lost before delayed distribution makes them available online.

Enhancements:
- Refocus BiliDanmakuMonitor on monitoring and statistics while injecting the verification service.
- Centralize Bili API client lifecycle management and reuse clients across monitoring and background verification workflows.

</details>

</details>

</details>

</details>

</details>

</details>

</details>