### PR TITLE
refactor(service): AuthService/VideoFetcher 改为纯依赖注入

### DIFF
--- a/src/danmaku_sender/controller/account_controller.py
+++ b/src/danmaku_sender/controller/account_controller.py
@@ -10,6 +10,7 @@ from danmaku_sender.types.models.user import UserProfile
 from danmaku_sender.config import ApiAuthConfig
 from danmaku_sender.runtime.state.app_state import AppState
 from danmaku_sender.runtime.managers.account_manager import AccountManager
+from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.service.auth_service import AuthService
 
 
@@ -46,7 +47,7 @@ class AccountController(QObject):
     def check_account(self, account: AccountCredential, config: ApiAuthConfig):
         """异步检测账号是否有效"""
         PoolTask.submit(
-            AuthService.check_login,
+            self._task_check_login,
             lambda result: self.checkFinished.emit(account, result),
             lambda _: self.checkFinished.emit(account, False),
             config,
@@ -55,8 +56,20 @@ class AccountController(QObject):
     def fetch_user_info(self, account: AccountCredential, config: ApiAuthConfig):
         """异步获取用户信息（昵称、uid）"""
         PoolTask.submit(
-            AuthService.fetch_raw_user_info,
+            self._task_fetch_user_info,
             lambda result: self.userInfoFetched.emit(account, result),
             lambda _: self.userInfoFetched.emit(account, None),
             config,
         )
+
+    # ---- 后台任务 ----
+
+    def _task_check_login(self, config: ApiAuthConfig) -> bool:
+        """检测账号是否有效（后台线程执行）"""
+        with BiliApiClient.from_config(config) as client:
+            return AuthService(client).check_login()
+
+    def _task_fetch_user_info(self, config: ApiAuthConfig) -> dict | None:
+        """获取用户信息（后台线程执行）"""
+        with BiliApiClient.from_config(config) as client:
+            return AuthService(client).fetch_raw_user_info()

--- a/src/danmaku_sender/controller/auth_controller.py
+++ b/src/danmaku_sender/controller/auth_controller.py
@@ -7,6 +7,7 @@ from .concurrency import WorkerThread, PoolTask
 
 from danmaku_sender.config import ApiAuthConfig
 from danmaku_sender.types.models.user import UserProfile
+from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.service.auth_service import AuthService
 
 
@@ -34,11 +35,16 @@ class AuthController(QObject):
             return
 
         PoolTask.submit(
-            AuthService.fetch_user_profile,
+            self._task_fetch_profile,
             self.userProfileReady.emit,
             lambda _: self.userProfileReady.emit(UserProfile(False, "未登录")),
             auth_config,
         )
+
+    def _task_fetch_profile(self, auth_config: ApiAuthConfig) -> UserProfile:
+        """获取用户信息（后台线程执行）"""
+        with BiliApiClient.from_config(auth_config) as client:
+            return AuthService(client).fetch_user_profile()
 
     def start_qr_login(self, use_system_proxy: bool):
         """启动扫码登录后台任务"""
@@ -96,7 +102,17 @@ class QRLoginWorker(WorkerThread):
 
     def run(self):
         try:
-            with AuthService.qr_login_session(self.use_system_proxy) as (client, url, qrcode_key):
+            config = ApiAuthConfig(sessdata="", bili_jct="", use_system_proxy=self.use_system_proxy)
+            with BiliApiClient.from_config(config) as client:
+                # 生成二维码
+                data = client.generate_qr_code()
+                url = data.get('url')
+                qrcode_key = data.get('qrcode_key')
+
+                if not url or not qrcode_key:
+                    self.loginFailed.emit("获取二维码失败：B站接口返回异常")
+                    return
+
                 # 通知 UI 渲染二维码
                 self.qrReady.emit(url)
                 self.statusUpdated.emit("请使用哔哩哔哩客户端扫码")

--- a/src/danmaku_sender/controller/video_controller.py
+++ b/src/danmaku_sender/controller/video_controller.py
@@ -4,6 +4,7 @@ from PySide6.QtCore import QObject, Signal, QThreadPool, Slot
 
 from danmaku_sender.types.models.video import VideoInfo
 from danmaku_sender.config import ApiAuthConfig
+from danmaku_sender.repo.bili_api_client import BiliApiClient
 from danmaku_sender.service.video_fetcher import VideoFetcher
 from .concurrency import PoolTask
 
@@ -49,7 +50,7 @@ class VideoController(QObject):
         if not is_background:
             self.fetchStarted.emit()
 
-        task = PoolTask(VideoFetcher.fetch_info_from_config, bvid, auth_config)
+        task = PoolTask(self._task_fetch_info, bvid, auth_config)
 
         @Slot(object)
         def _on_fetch_succeeded(info: VideoInfo):
@@ -76,7 +77,7 @@ class VideoController(QObject):
         if not bvids:
             return
 
-        task = PoolTask(VideoFetcher.fetch_infos_from_config, bvids, auth_config)
+        task = PoolTask(self._task_fetch_infos, bvids, auth_config)
 
         @Slot(list)
         def _on_fetch_completed(results: list[tuple[str, VideoInfo | Exception]]):
@@ -88,3 +89,22 @@ class VideoController(QObject):
 
         task.signals.result.connect(_on_fetch_completed)
         _bg_fetch_pool.start(task)
+
+    # ---- 后台任务 ----
+
+    def _task_fetch_info(self, bvid: str, auth_config: ApiAuthConfig) -> VideoInfo:
+        """获取单条视频信息（后台线程执行）"""
+        with BiliApiClient.from_config(auth_config) as client:
+            return VideoFetcher(client).fetch_info(bvid)
+
+    def _task_fetch_infos(self, bvids: list[str], auth_config: ApiAuthConfig) -> list[tuple[str, VideoInfo | Exception]]:
+        """批量获取视频信息（后台线程执行）"""
+        results = []
+        with BiliApiClient.from_config(auth_config) as client:
+            fetcher = VideoFetcher(client)
+            for bvid in bvids:
+                try:
+                    results.append((bvid, fetcher.fetch_info(bvid)))
+                except Exception as e:
+                    results.append((bvid, e))
+        return results

--- a/src/danmaku_sender/service/auth_service.py
+++ b/src/danmaku_sender/service/auth_service.py
@@ -1,8 +1,8 @@
 """
 认证服务层
 
-封装 B 站用户认证相关的 API 操作，controller 层不直接接触 BiliApiClient。
-纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
+封装 B 站用户认证相关的 API 操作。
+纯依赖注入设计：不管理连接生命周期，由 Controller 层负责创建 BiliApiClient 并注入。
 """
 
 import logging

--- a/src/danmaku_sender/service/auth_service.py
+++ b/src/danmaku_sender/service/auth_service.py
@@ -2,82 +2,61 @@
 认证服务层
 
 封装 B 站用户认证相关的 API 操作，controller 层不直接接触 BiliApiClient。
+纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
 """
 
 import logging
-from contextlib import contextmanager
 
 from danmaku_sender.repo.bili_api_client import BiliApiClient
-from danmaku_sender.types.exceptions.exceptions import BiliApiError
 from danmaku_sender.types.models.user import UserProfile
-from danmaku_sender.config import ApiAuthConfig
 
 
 logger = logging.getLogger(__name__)
 
 
 class AuthService:
-    """B 站用户认证服务"""
+    """
+    B 站用户认证服务
 
-    @staticmethod
-    def fetch_user_profile(auth_config: ApiAuthConfig) -> UserProfile:
+    纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
+    """
+
+    def __init__(self, api_client: BiliApiClient):
+        self.client = api_client
+
+    def fetch_user_profile(self) -> UserProfile:
         """获取当前登录用户的完整信息（含头像）"""
-        with BiliApiClient.from_config(auth_config) as client:
-            nav_data = client.get_user_info()
+        nav_data = self.client.get_user_info()
 
-            if not nav_data.get('isLogin'):
-                return UserProfile(is_login=False, username="未登录")
+        if not nav_data.get('isLogin'):
+            return UserProfile(is_login=False, username="未登录")
 
-            uid = nav_data.get('mid', 0)
-            username = nav_data.get('uname', "未知用户")
-            face_url = nav_data.get('face', "")
+        uid = nav_data.get('mid', 0)
+        username = nav_data.get('uname', "未知用户")
+        face_url = nav_data.get('face', "")
 
-            avatar_data = b""
-            if face_url:
-                try:
-                    avatar_data = client.get_raw_resource(face_url)
-                except Exception as e:
-                    logger.warning(f"下载头像失败 [URL: {face_url}]", exc_info=True)
+        avatar_data = b""
+        if face_url:
+            try:
+                avatar_data = self.client.get_raw_resource(face_url)
+            except Exception as e:
+                logger.warning(f"下载头像失败 [URL: {face_url}]", exc_info=True)
 
-            return UserProfile(is_login=True, username=username, uid=uid, avatar_bytes=avatar_data)
+        return UserProfile(is_login=True, username=username, uid=uid, avatar_bytes=avatar_data)
 
-    @staticmethod
-    def check_login(auth_config: ApiAuthConfig) -> bool:
+    def check_login(self) -> bool:
         """检测账号是否处于登录状态"""
         try:
-            with BiliApiClient.from_config(auth_config) as client:
-                nav = client.get_user_info()
-                return bool(nav.get('isLogin'))
+            nav = self.client.get_user_info()
+            return bool(nav.get('isLogin'))
         except Exception as e:
             logger.debug(f"账号检测失败: {e}")
             return False
 
-    @staticmethod
-    def fetch_raw_user_info(auth_config: ApiAuthConfig) -> dict | None:
+    def fetch_raw_user_info(self) -> dict | None:
         """获取原始用户信息字典"""
         try:
-            with BiliApiClient.from_config(auth_config) as client:
-                return client.get_user_info()
+            return self.client.get_user_info()
         except Exception as e:
             logger.debug(f"获取用户信息失败: {e}")
             return None
-
-    @staticmethod
-    @contextmanager
-    def qr_login_session(use_system_proxy: bool):
-        """
-        二维码登录会话上下文管理器。
-
-        Yields:
-            (client, qr_url, qrcode_key) — 登录客户端、二维码 URL、轮询 key
-        """
-        config = ApiAuthConfig(sessdata="", bili_jct="", use_system_proxy=use_system_proxy)
-        with BiliApiClient.from_config(config) as client:
-            data = client.generate_qr_code()
-            url = data.get('url')
-            qrcode_key = data.get('qrcode_key')
-
-            if not url or not qrcode_key:
-                raise BiliApiError(code=-1, message="获取二维码失败：B站接口返回异常")
-
-            yield client, url, qrcode_key

--- a/src/danmaku_sender/service/video_fetcher.py
+++ b/src/danmaku_sender/service/video_fetcher.py
@@ -1,39 +1,26 @@
+"""
+视频业务服务层
+
+负责协调 API 调用与数据转换。
+纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
+"""
+
 import logging
 
 from danmaku_sender.types.models.video import VideoInfo, VideoPart
-from danmaku_sender.config import ApiAuthConfig
 from danmaku_sender.repo.bili_api_client import BiliApiClient
 
 
 class VideoFetcher:
     """
     视频业务服务层
-    负责协调 API 调用与数据转换
+
+    纯依赖注入设计：不管理连接生命周期，由调用方负责创建和注入依赖。
     """
+
     def __init__(self, api_client: BiliApiClient, logger: logging.Logger | None = None):
         self.client = api_client
         self.logger = logger if logger else logging.getLogger(__name__)
-
-    @classmethod
-    def fetch_info_from_config(cls, bvid: str, auth_config: ApiAuthConfig) -> VideoInfo:
-        """从配置直接获取单条视频信息（内部管理 client 生命周期）"""
-        with BiliApiClient.from_config(auth_config) as client:
-            return cls(client).fetch_info(bvid)
-
-    @classmethod
-    def fetch_infos_from_config(
-        cls, bvids: list[str], auth_config: ApiAuthConfig
-    ) -> list[tuple[str, VideoInfo | Exception]]:
-        """批量获取视频信息（复用 HTTP 连接）"""
-        results = []
-        with BiliApiClient.from_config(auth_config) as client:
-            fetcher = cls(client)
-            for bvid in bvids:
-                try:
-                    results.append((bvid, fetcher.fetch_info(bvid)))
-                except Exception as e:
-                    results.append((bvid, e))
-        return results
 
     def fetch_info(self, bvid: str) -> VideoInfo:
         """


### PR DESCRIPTION
- AuthService 删除所有 @staticmethod，改为实例方法
- VideoFetcher 删除 @classmethod，保留 fetch_info 实例方法
- Controller 层负责装配（创建 client、创建 service、调用方法）
- 消除闭包，改为私有方法 _task_xxx

## Sourcery 摘要

围绕显式依赖注入和由控制器管理的后台任务，重构服务集成。

增强功能：
- 重构身份验证和视频服务，以使用注入的 API 客户端，同时将客户端生命周期管理交由控制器负责。
- 将后台任务编排以及 API 客户端/服务组装移至由控制器负责的任务方法中。
- 将服务级别的二维码登录会话管理替换为由控制器管理的二维码登录设置和验证。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

围绕显式依赖注入和由控制器管理的后台任务，重构服务集成。

增强功能：
- 重构身份验证和视频服务，使用显式注入的 API 客户端，不再管理客户端生命周期。
- 将 API 客户端和服务的组装、二维码登录设置以及后台任务编排移至控制器中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor service integrations around explicit dependency injection and controller-managed background tasks.

Enhancements:
- Refactor authentication and video services to use explicitly injected API clients without managing client lifecycles.
- Move API client and service assembly, QR login setup, and background task orchestration into controllers.

</details>

</details>