### PR TITLE
test: 修复补全重构后失效缺失的测试套件，新增 CI 测试工作流

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: python -m pip install -e .[dev]
+
+      - name: Run tests
+        run: python -m pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Qt system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libgl1 libxkbcommon0 libdbus-1-3 libfontconfig1
+
       - name: Install dependencies
         run: python -m pip install -e .[dev]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """共享测试夹具与辅助函数"""
-from danmaku_sender.core.models.danmaku import Danmaku
+from danmaku_sender.types.models.danmaku import Danmaku
 
 
 def make_danmaku(msg: str = "弹幕", progress: int = 1000, **kwargs) -> Danmaku:

--- a/tests/test_engines/test_editor_session.py
+++ b/tests/test_engines/test_editor_session.py
@@ -1,9 +1,9 @@
 """EditorSession 单元测试 — 编辑器核心会话层"""
 import pytest
-from danmaku_sender.core.models.danmaku import Danmaku
-from danmaku_sender.core.models.editor_types import EditorField, InsertPosition
-from danmaku_sender.core.state import ValidationConfig
-from danmaku_sender.core.engines.editor_session import EditorSession
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.editor_types import EditorField, InsertPosition
+from danmaku_sender.config import ValidationConfig
+from danmaku_sender.service.editor_session import EditorSession
 from tests.conftest import make_danmaku as _dm
 
 

--- a/tests/test_engines/test_sender/test_context.py
+++ b/tests/test_engines/test_sender/test_context.py
@@ -1,9 +1,9 @@
 """SendingContext / SendJob 单元测试"""
 import pytest
-from danmaku_sender.core.models.danmaku import Danmaku
-from danmaku_sender.core.models.common import VideoTarget
-from danmaku_sender.core.state import SenderConfig
-from danmaku_sender.core.engines.sender.context import SendingContext, SendJob
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.common import VideoTarget
+from danmaku_sender.config import SenderConfig
+from danmaku_sender.service.sender.context import SendingContext, SendJob
 from threading import Event
 
 
@@ -11,7 +11,6 @@ from threading import Event
 def sending_context() -> SendingContext:
     return SendingContext(
         total=10,
-        config=SenderConfig(),
         target=VideoTarget(bvid="BV1xx411c7mD", cid=1001)
     )
 

--- a/tests/test_engines/test_sender/test_delay_manager.py
+++ b/tests/test_engines/test_sender/test_delay_manager.py
@@ -1,42 +1,42 @@
 """DelayManager 单元测试"""
 from threading import Event
 from unittest.mock import MagicMock, patch
-from danmaku_sender.core.engines.sender.delay_manager import DelayManager
+from danmaku_sender.service.sender.delay_manager import DelayManager
 
 
 class TestCalcEta:
     """calc_eta 静态方法 — 纯算术，最有价值的测试目标"""
 
     def test_zero_progress(self):
-        eta = DelayManager.calc_eta(attempted=0, total=10, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=10, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         # remaining_waits = 10 - max(1,0) = 9, burst_size<=1 → burst_size=1 → 9 * 8 = 72
         assert eta == 72.0
 
     def test_first_attempt(self):
-        eta = DelayManager.calc_eta(attempted=1, total=10, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=1, total=10, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         assert eta == 72.0  # same as attempted=0
 
     def test_half_done(self):
-        eta = DelayManager.calc_eta(attempted=5, total=10, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=5, total=10, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         # remaining = 10 - 5 = 5 → 5 * 8 = 40
         assert eta == 40.0
 
     def test_all_done(self):
-        eta = DelayManager.calc_eta(attempted=10, total=10, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=10, total=10, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         assert eta == 0.0
 
     def test_over_attempted(self):
-        eta = DelayManager.calc_eta(attempted=15, total=10, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=15, total=10, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         assert eta == 0.0
 
     def test_single_item(self):
-        eta = DelayManager.calc_eta(attempted=0, total=1, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=1, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         # remaining = 1 - max(1,0) = 0
         assert eta == 0.0
 
     def test_burst_mode_simple(self):
         """burst_size=2, total=4, 每发2条休息一次"""
-        eta = DelayManager.calc_eta(attempted=0, total=4, burst_size=2, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=4, burst_enabled=True, burst_size=2, avg_normal=8.0, avg_rest=40.0)
         # waits in [1, 3]: 1, 2, 3
         # rest: 2 (index % 2 == 0) → rest_count=1
         # normal: 3-1 = 2
@@ -45,21 +45,21 @@ class TestCalcEta:
 
     def test_burst_size_1_behaves_as_normal(self):
         """burst_size=1 时退化为纯普通延时"""
-        eta = DelayManager.calc_eta(attempted=0, total=5, burst_size=1, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=5, burst_enabled=True, burst_size=1, avg_normal=8.0, avg_rest=40.0)
         assert eta == 4 * 8.0  # 4 waits * 8s
 
     def test_burst_size_zero_behaves_as_normal(self):
         """burst_size=0 时退化为纯普通延时"""
-        eta = DelayManager.calc_eta(attempted=0, total=5, burst_size=0, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=5, burst_enabled=False, burst_size=0, avg_normal=8.0, avg_rest=40.0)
         assert eta == 4 * 8.0
 
     def test_negative_burst_size_behaves_as_normal(self):
-        eta = DelayManager.calc_eta(attempted=0, total=5, burst_size=-1, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=5, burst_enabled=False, burst_size=-1, avg_normal=8.0, avg_rest=40.0)
         assert eta == 4 * 8.0
 
     def test_large_burst_no_rests(self):
         """burst_size > total - 1 时不会触发任何休息"""
-        eta = DelayManager.calc_eta(attempted=0, total=5, burst_size=100, avg_normal=8.0, avg_rest=40.0)
+        eta = DelayManager.calc_eta(attempted=0, total=5, burst_enabled=True, burst_size=100, avg_normal=8.0, avg_rest=40.0)
         assert eta == 4 * 8.0
 
 
@@ -84,7 +84,7 @@ class TestWaitAndCheckStop:
         assert stop.wait.call_args[1]["timeout"] == 8.5
 
     def test_burst_rest_triggered(self, monkeypatch):
-        dm = DelayManager(normal_min=8.0, normal_max=8.5, burst_size=2, rest_min=40.0, rest_max=45.0)
+        dm = DelayManager(normal_min=8.0, normal_max=8.5, burst_enabled=True, burst_size=2, rest_min=40.0, rest_max=45.0)
         stop = Event()
 
         delays = []

--- a/tests/test_engines/test_sender/test_pipeline_record.py
+++ b/tests/test_engines/test_sender/test_pipeline_record.py
@@ -1,0 +1,101 @@
+"""发送管线存证回归 — 发送成功后记录必须真实落库
+
+回归 2026-09 存证静默丢失事故：POST 成功但数据库无记录时，本测试会在 CI 当场变红。
+"""
+import sqlite3
+import threading
+
+import pytest
+
+from danmaku_sender.config import ApiAuthConfig, SenderConfig
+from danmaku_sender.repo.history_manager import HistoryManager
+from danmaku_sender.service.sender import SendPipeline, SendJob
+from danmaku_sender.service.sender import pipeline as pipeline_mod
+from danmaku_sender.types.models.common import VideoTarget
+from danmaku_sender.types.models.danmaku import Danmaku
+
+
+SENT_DMIDS: list[str] = []
+
+
+class StubClient:
+    """伪 B 站客户端：POST 恒成功并返回递增 dmid"""
+
+    def __init__(self, auth_config):
+        pass
+
+    @classmethod
+    def from_config(cls, auth_config):
+        return cls(auth_config)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post_danmaku(self, cid, bvid, params):
+        dmid = str(900000000000000000 + len(SENT_DMIDS))
+        SENT_DMIDS.append(dmid)
+        return {"code": 0, "message": "0", "data": {"dmid_str": dmid, "visible": True}}
+
+
+@pytest.fixture
+def pipeline_env(tmp_path, monkeypatch) -> HistoryManager:
+    hm = HistoryManager(tmp_path / "history.db")
+    monkeypatch.setattr(pipeline_mod, "BiliApiClient", StubClient)
+    return hm
+
+
+def _run_pipeline(hm: HistoryManager, target: VideoTarget, danmakus: list[Danmaku]) -> None:
+    """在独立线程中执行管线，与 QueueWorker 的真实调用方式一致"""
+    pipeline = SendPipeline(
+        ApiAuthConfig(sessdata="x", bili_jct="y", use_system_proxy=False), hm
+    )
+    job = SendJob(
+        target=target,
+        danmakus=danmakus,
+        config=SenderConfig(min_delay=0.1, max_delay=0.2),
+        stop_event=threading.Event(),
+    )
+    errors: list[Exception] = []
+
+    def runner():
+        try:
+            pipeline.execute(job)
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+
+    t = threading.Thread(target=runner)
+    t.start()
+    t.join()
+    assert not errors, f"管线执行异常: {errors}"
+
+
+class TestPipelineRecord:
+    def test_successful_send_records_to_db(self, pipeline_env):
+        """每条发送成功的弹幕都必须有存证行"""
+        hm = pipeline_env
+        target = VideoTarget(bvid="BV1xx", cid=1001, title="T")
+        _run_pipeline(hm, target, [Danmaku(msg="a", progress=1000), Danmaku(msg="b", progress=2000)])
+
+        conn = sqlite3.connect(hm.db_path)
+        rows = conn.execute("SELECT dmid, cid, status FROM sent_danmaku ORDER BY dmid").fetchall()
+        conn.close()
+        assert len(rows) == 2
+        assert all(r[1] == 1001 for r in rows)
+        assert all(r[2] == 0 for r in rows)  # PENDING
+
+    def test_failed_post_leaves_no_record(self, pipeline_env, monkeypatch):
+        """发送失败的弹幕不应有存证"""
+        hm = pipeline_env
+
+        def fail_post(self, cid, bvid, params):
+            return {"code": -400, "message": "请求错误", "data": {}}
+
+        monkeypatch.setattr(StubClient, "post_danmaku", fail_post)
+        target = VideoTarget(bvid="BV1xx", cid=1001, title="T")
+        _run_pipeline(hm, target, [Danmaku(msg="a", progress=1000)])
+
+        n = sqlite3.connect(hm.db_path).execute("SELECT COUNT(*) FROM sent_danmaku").fetchone()[0]
+        assert n == 0

--- a/tests/test_exceptions/test_api_errors.py
+++ b/tests/test_exceptions/test_api_errors.py
@@ -1,6 +1,6 @@
 """BiliDmErrorCode 枚举单元测试"""
 import pytest
-from danmaku_sender.core.exceptions.api_errors import BiliDmErrorCode, ERROR_METADATA
+from danmaku_sender.types.exceptions.api_errors import BiliDmErrorCode, ERROR_METADATA
 
 
 class TestFromCode:

--- a/tests/test_exceptions/test_exceptions.py
+++ b/tests/test_exceptions/test_exceptions.py
@@ -1,6 +1,6 @@
 """自定义异常类单元测试"""
 import pytest
-from danmaku_sender.core.exceptions.exceptions import BiliNetworkError, BiliApiError
+from danmaku_sender.types.exceptions.exceptions import BiliNetworkError, BiliApiError
 
 
 class TestBiliNetworkError:

--- a/tests/test_models/test_common.py
+++ b/tests/test_models/test_common.py
@@ -1,5 +1,5 @@
 """common 模型单元测试 — VideoTarget, DanmakuStatus"""
-from danmaku_sender.core.models.common import VideoTarget
+from danmaku_sender.types.models.common import VideoTarget
 
 
 class TestVideoTarget:

--- a/tests/test_models/test_danmaku.py
+++ b/tests/test_models/test_danmaku.py
@@ -1,5 +1,5 @@
 """Danmaku 模型单元测试"""
-from danmaku_sender.core.models.danmaku import Danmaku
+from danmaku_sender.types.models.danmaku import Danmaku
 
 
 class TestDanmakuDefaults:

--- a/tests/test_models/test_editor_types.py
+++ b/tests/test_models/test_editor_types.py
@@ -1,7 +1,7 @@
 """editor_types 模型单元测试 — EditorField, EditorItem"""
 import pytest
-from danmaku_sender.core.models.danmaku import Danmaku
-from danmaku_sender.core.models.editor_types import EditorItem, EditorField
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.editor_types import EditorItem, EditorField
 
 
 @pytest.fixture

--- a/tests/test_models/test_result.py
+++ b/tests/test_models/test_result.py
@@ -1,6 +1,6 @@
 """DanmakuSendResult 模型单元测试"""
-from danmaku_sender.core.models.result import DanmakuSendResult
-from danmaku_sender.core.exceptions.api_errors import BiliDmErrorCode
+from danmaku_sender.types.models.result import DanmakuSendResult
+from danmaku_sender.types.exceptions.api_errors import BiliDmErrorCode
 
 
 class TestFromApiResponse:

--- a/tests/test_models/test_video.py
+++ b/tests/test_models/test_video.py
@@ -1,6 +1,6 @@
 """VideoInfo / VideoPart 模型单元测试"""
 import pytest
-from danmaku_sender.core.models.video import VideoInfo, VideoPart
+from danmaku_sender.types.models.video import VideoInfo, VideoPart
 
 
 @pytest.fixture

--- a/tests/test_repo/test_history_manager.py
+++ b/tests/test_repo/test_history_manager.py
@@ -1,0 +1,112 @@
+"""HistoryManager 单元测试 — 存证/核销/标记丢失/统计
+
+包含 2026-09 存证静默丢失事故的回归测试：发送成功后记录必须真实落库可查。
+"""
+import sqlite3
+
+import pytest
+
+from danmaku_sender.repo.history_manager import HistoryManager
+from danmaku_sender.types.models.common import VideoTarget, DanmakuStatus
+from danmaku_sender.types.models.danmaku import Danmaku
+
+
+@pytest.fixture
+def target() -> VideoTarget:
+    return VideoTarget(bvid="BV1xx411c7mD", cid=1001, title="T")
+
+
+@pytest.fixture
+def hm(tmp_path) -> HistoryManager:
+    return HistoryManager(tmp_path / "history.db")
+
+
+def _record(hm: HistoryManager, target: VideoTarget, dmid: str, msg: str = "弹幕") -> bool:
+    return hm.record_danmaku(target, Danmaku(msg=msg, progress=1000, dmid=dmid))
+
+
+class TestRecordDanmaku:
+    """存证回归：发送成功后记录必须真实落库"""
+
+    def test_record_persists_row(self, hm, target):
+        _record(hm, target, "dm1")
+        row = sqlite3.connect(hm.db_path).execute(
+            "SELECT dmid, cid, status FROM sent_danmaku WHERE dmid='dm1'"
+        ).fetchone()
+        assert row == ("dm1", 1001, DanmakuStatus.PENDING.value)
+
+    def test_record_conflict_ignored(self, hm, target):
+        """同 dmid 二次存证被忽略，不产生重复行"""
+        _record(hm, target, "dm1")
+        _record(hm, target, "dm1")
+        n = sqlite3.connect(hm.db_path).execute("SELECT COUNT(*) FROM sent_danmaku").fetchone()[0]
+        assert n == 1
+
+    def test_record_without_dmid_skipped(self, hm, target):
+        """POST 响应缺 dmid 时跳过存证"""
+        _record(hm, target, "")
+        n = sqlite3.connect(hm.db_path).execute("SELECT COUNT(*) FROM sent_danmaku").fetchone()[0]
+        assert n == 0
+
+    def test_init_is_idempotent(self, hm, target):
+        """重启等场景下重复初始化不得破坏既有数据"""
+        _record(hm, target, "dm1")
+        hm2 = HistoryManager(hm.db_path)
+        assert hm2.get_stats(1001) == (1, 0, 0)
+
+
+class TestVerifyAndLost:
+    """核销与标记丢失"""
+
+    def test_verify_flips_pending_to_verified(self, hm, target):
+        _record(hm, target, "dm1")
+        _record(hm, target, "dm2")
+        assert hm.verify_dmids(["dm1", "dm-not-exist"]) == 1
+        assert hm.get_stats(1001) == (2, 1, 0)
+
+    def test_verify_does_not_touch_verified(self, hm, target):
+        """已存活的弹幕不会被重复核销"""
+        _record(hm, target, "dm1")
+        hm.verify_dmids(["dm1"])
+        assert hm.verify_dmids(["dm1"]) == 0
+
+    def test_mark_as_lost_excludes_verified(self, hm, target):
+        _record(hm, target, "dm1")
+        _record(hm, target, "dm2")
+        hm.verify_dmids(["dm1"])
+        assert hm.mark_as_lost(1001, ["dm1"]) == 1  # 仅未在线的 dm2
+        assert hm.get_stats(1001) == (2, 1, 1)
+
+    def test_mark_as_lost_keeps_row_present(self, hm, target):
+        """丢失是标记而非删除"""
+        _record(hm, target, "dm1")
+        hm.mark_as_lost(1001, [])
+        n = sqlite3.connect(hm.db_path).execute("SELECT COUNT(*) FROM sent_danmaku").fetchone()[0]
+        assert n == 1
+
+
+class TestStatsAndDedup:
+    """统计与断点续传查重"""
+
+    def test_get_stats_with_baseline(self, hm, target):
+        _record(hm, target, "dm1")
+        import time
+        conn = sqlite3.connect(hm.db_path)
+        conn.execute("UPDATE sent_danmaku SET ctime=? WHERE dmid='dm1'", (time.time() - 3600,))
+        conn.commit()
+        conn.close()
+        _record(hm, target, "dm2")
+
+        assert hm.get_stats(1001, stats_baseline=time.time() - 60) == (1, 0, 0)
+        assert hm.get_stats(1001) == (2, 0, 0)
+
+    def test_count_records_for_dedup(self, hm, target):
+        """断点续传计数：PENDING/VERIFIED 计入，LOST 不计入（可重发）"""
+        dm = Danmaku(msg="重复弹幕", progress=1000)
+        _record(hm, target, "dm1", msg="重复弹幕")
+        _record(hm, target, "dm2", msg="重复弹幕")
+        assert hm.count_records(target, dm) == 2      # PENDING 计入
+        hm.verify_dmids(["dm1"])
+        assert hm.count_records(target, dm) == 2      # VERIFIED 计入
+        hm.mark_as_lost(1001, ["dm1"])                # dm2 被标记丢失
+        assert hm.count_records(target, dm) == 1      # LOST 不计入（只剩 VERIFIED 的 dm1）

--- a/tests/test_services/test_danmaku_validator.py
+++ b/tests/test_services/test_danmaku_validator.py
@@ -1,7 +1,7 @@
 """danmaku_validator 单元测试 — validate_danmaku_list"""
 import pytest
-from danmaku_sender.core.state import ValidationConfig
-from danmaku_sender.core.services.danmaku_validator import validate_danmaku_list, FORBIDDEN_SYMBOLS
+from danmaku_sender.config import ValidationConfig
+from danmaku_sender.service.danmaku_validator import validate_danmaku_list, FORBIDDEN_SYMBOLS
 from tests.conftest import make_danmaku as _dm
 
 

--- a/tests/test_state/test_state.py
+++ b/tests/test_state/test_state.py
@@ -1,8 +1,12 @@
-"""Pydantic 配置模型单元测试 — SenderConfig, MonitorConfig, ValidationConfig, VideoState"""
+"""状态与配置模型单元测试 — SenderConfig, MonitorConfig, ValidationConfig, QueueState"""
 import pytest
 from pydantic import ValidationError
-from danmaku_sender.core.models.danmaku import Danmaku
-from danmaku_sender.core.state import SenderConfig, MonitorConfig, ValidationConfig, VideoState
+
+from danmaku_sender.types.models.danmaku import Danmaku
+from danmaku_sender.types.models.common import VideoTarget
+from danmaku_sender.types.models.queue import QueueTask, TaskStatus
+from danmaku_sender.config import SenderConfig, MonitorConfig, ValidationConfig
+from danmaku_sender.runtime.state.queue_state import QueueState
 
 
 class TestSenderConfig:
@@ -44,11 +48,11 @@ class TestSenderConfig:
 
     def test_rest_min_greater_than_rest_max_raises(self):
         with pytest.raises(ValidationError, match="爆发休息的最小值不能大于最大值"):
-            SenderConfig(burst_size=3, rest_min=50.0, rest_max=30.0)
+            SenderConfig(burst_enabled=True, burst_size=3, rest_min=50.0, rest_max=30.0)
 
-    def test_rest_min_greater_than_rest_max_burst_size_1_ok(self):
-        """burst_size <= 1 时不校验 rest_min/rest_max"""
-        cfg = SenderConfig(burst_size=1, rest_min=50.0, rest_max=30.0)
+    def test_rest_range_ignored_when_burst_disabled(self):
+        """burst_enabled=False 时不校验 rest_min/rest_max"""
+        cfg = SenderConfig(burst_size=3, rest_min=50.0, rest_max=30.0)
         assert cfg.rest_min == 50.0
 
     def test_validate_assignment(self):
@@ -89,36 +93,80 @@ class TestValidationConfig:
         assert cfg.enabled is False
 
 
-class TestVideoState:
-    def test_default_state(self):
-        vs = VideoState()
-        assert vs.bvid == ""
-        assert vs.selected_cid is None
-        assert vs.loaded_danmakus == []
-        assert vs.is_ready_to_send is False
-        assert vs.danmaku_count == 0
+def make_task(cid: int = 1, status: TaskStatus = TaskStatus.PENDING) -> QueueTask:
+    return QueueTask(
+        target=VideoTarget(bvid=f"BV{cid:03d}", cid=cid, title=f"T{cid}"),
+        danmakus=[],
+        config_snapshot=SenderConfig(),
+        status=status,
+    )
 
-    def test_ready_to_send_all_set(self):
-        vs = VideoState(
-            bvid="BV1xx411c7mD",
-            selected_cid=1001,
-            loaded_danmakus=[Danmaku(msg="t", progress=0)]
-        )
-        assert vs.is_ready_to_send is True
 
-    def test_not_ready_missing_bvid(self):
-        vs = VideoState(selected_cid=1001, loaded_danmakus=[Danmaku(msg="t", progress=0)])
-        assert vs.is_ready_to_send is False
+class TestQueueState:
+    """QueueState 队列操作与信号"""
 
-    def test_not_ready_missing_cid(self):
-        vs = VideoState(bvid="BV1xx411c7mD", loaded_danmakus=[Danmaku(msg="t", progress=0)])
-        assert vs.is_ready_to_send is False
+    def test_add_and_lookup(self):
+        qs = QueueState()
+        t = make_task(1)
+        qs.add_task(t)
+        assert not qs.is_empty
+        assert qs.pending_count == 1
+        assert qs.get_task_by_id(t.task_id) is t
 
-    def test_not_ready_empty_danmakus(self):
-        vs = VideoState(bvid="BV1xx411c7mD", selected_cid=1001)
-        assert vs.is_ready_to_send is False
+    def test_remove_only_pending_or_unconfigured(self):
+        qs = QueueState()
+        running = make_task(1, TaskStatus.RUNNING)
+        pending = make_task(2)
+        qs.add_task(running)
+        qs.add_task(pending)
+        assert qs.remove_task(running.task_id) is False
+        assert qs.remove_task(pending.task_id) is True
+        assert qs.get_task_by_id(pending.task_id) is None
 
-    def test_danmaku_count(self):
-        dms = [Danmaku(msg=f"d{i}", progress=i * 1000) for i in range(5)]
-        vs = VideoState(loaded_danmakus=dms)
-        assert vs.danmaku_count == 5
+    def test_move_task(self):
+        qs = QueueState()
+        t1, t2, t3 = make_task(1), make_task(2), make_task(3)
+        for t in (t1, t2, t3):
+            qs.add_task(t)
+        assert qs.move_task(t3.task_id, -1) is True
+        assert [t.target.cid for t in qs.tasks] == [1, 3, 2]
+        assert qs.move_task(t1.task_id, -1) is False  # 已在顶端
+
+    def test_move_non_movable_task(self):
+        qs = QueueState()
+        done = make_task(1, TaskStatus.COMPLETED)
+        other = make_task(2)
+        qs.add_task(done)
+        qs.add_task(other)
+        assert qs.move_task(done.task_id, 1) is False  # 已完成任务不可移动
+
+    def test_clear_completed_keeps_pending_and_paused(self):
+        qs = QueueState()
+        for t in (
+            make_task(1, TaskStatus.COMPLETED),
+            make_task(2, TaskStatus.FAILED),
+            make_task(3, TaskStatus.PENDING),
+            make_task(4, TaskStatus.PAUSED),
+        ):
+            qs.add_task(t)
+        qs.clear_completed()
+        assert [t.status for t in qs.tasks] == [TaskStatus.PENDING, TaskStatus.PAUSED]
+
+    def test_update_task_status(self):
+        qs = QueueState()
+        t = make_task(1)
+        qs.add_task(t)
+        events = []
+        qs.taskStatusChanged.connect(lambda tid, s: events.append((tid, s)))
+        qs.update_task_status(t.task_id, TaskStatus.RUNNING, "err")
+        assert t.status == TaskStatus.RUNNING
+        assert t.error_msg == "err"
+        assert events == [(t.task_id, TaskStatus.RUNNING.value)]
+
+    def test_current_index_signal(self):
+        qs = QueueState()
+        fired = []
+        qs.currentTaskChanged.connect(lambda i: fired.append(i))
+        qs.current_index = 2
+        assert qs.current_index == 2
+        assert fired == [2]

--- a/tests/test_utils/test_account_manager.py
+++ b/tests/test_utils/test_account_manager.py
@@ -1,31 +1,50 @@
-"""account_manager 单元测试 — 多账号存储"""
+"""AccountManager 单元测试 — 多账号加密存储"""
 import json
 import pytest
-from pathlib import Path
+from cryptography.fernet import Fernet
 
-from danmaku_sender.core.models.account import AccountCredential
-from danmaku_sender.utils import account_manager
-
-
-@pytest.fixture
-def accounts_file(tmp_path: Path, monkeypatch):
-    """将 accounts.json 路径重定向到临时目录"""
-    fake_path = tmp_path / "accounts.json"
-    monkeypatch.setattr(account_manager, "get_accounts_filepath", lambda: fake_path)
-    return fake_path
+from danmaku_sender.runtime.managers import account_manager
+from danmaku_sender.runtime.managers.account_manager import AccountManager
+from danmaku_sender.types.models.account import AccountCredential
 
 
 @pytest.fixture
-def mock_fernet(monkeypatch):
-    """mock 掉 _get_encryption_key，使用临时 Fernet 密钥"""
-    from cryptography.fernet import Fernet
-    key = Fernet.generate_key()
-    fernet = Fernet(key)
-    monkeypatch.setattr(
-        "danmaku_sender.utils.account_manager._get_encryption_key",
-        lambda: key
-    )
-    return fernet
+def accounts_path(tmp_path, monkeypatch):
+    """将 ACCOUNTS_PATH 重定向到临时目录"""
+    fake = tmp_path / "accounts.json"
+    monkeypatch.setattr(account_manager, "ACCOUNTS_PATH", fake)
+    return fake
+
+
+class FakeKeyring:
+    """内存版密钥环，可注入失败"""
+
+    def __init__(self):
+        self.store = {}
+        self.fail_get = False
+        self.fail_set = False
+
+    def get_password(self, service, username):
+        if self.fail_get:
+            raise RuntimeError("密钥环读取失败")
+        return self.store.get(username)
+
+    def set_password(self, service, username, value):
+        if self.fail_set:
+            raise RuntimeError("密钥环写入失败")
+        self.store[username] = value
+
+
+@pytest.fixture
+def keyring_fake(monkeypatch):
+    kr = FakeKeyring()
+    monkeypatch.setattr(account_manager, "keyring", kr)
+    return kr
+
+
+@pytest.fixture
+def manager():
+    return AccountManager()
 
 
 class TestAccountCredential:
@@ -53,68 +72,82 @@ class TestAccountCredential:
 class TestLoadAccounts:
     """load_accounts"""
 
-    def test_no_file_returns_empty(self, accounts_file, mock_fernet):
-        assert account_manager.load_accounts() == []
+    def test_no_file_returns_empty(self, accounts_path, keyring_fake, manager):
+        assert manager.load_accounts() == []
 
-    def test_save_then_load_roundtrip(self, accounts_file, mock_fernet):
+    def test_save_then_load_roundtrip(self, accounts_path, keyring_fake, manager):
         original = [
             AccountCredential(uid=1, name="A", sessdata="s1", bili_jct="j1"),
             AccountCredential(uid=2, name="B", sessdata="s2", bili_jct="j2"),
         ]
-        account_manager.save_accounts(original)
-        loaded = account_manager.load_accounts()
-        assert loaded == original
+        manager.save_accounts(original)
+        assert manager.load_accounts() == original
 
-    def test_corrupted_file_returns_empty(self, accounts_file, mock_fernet):
-        """InvalidToken 路径: 非 Fernet 数据"""
-        accounts_file.write_bytes(b"not-valid-fernet-data")
-        assert account_manager.load_accounts() == []
-        assert not accounts_file.exists()  # 损坏文件应被删除
+    def test_key_not_persisted_save_skips_write(self, accounts_path, keyring_fake, manager):
+        """密钥环写入失败（persisted=False）时，跳过写盘以避免产生无法解密的文件"""
+        keyring_fake.fail_set = True
+        manager.save_accounts([AccountCredential(sessdata="s", bili_jct="j")])
+        assert not accounts_path.exists()
 
-    def test_decrypted_garbage_returns_empty(self, accounts_file, mock_fernet):
-        """JSONDecodeError 路径: 解密成功但内容不是合法 JSON"""
-        fernet = mock_fernet
-        accounts_file.write_bytes(fernet.encrypt(b"not-json"))
-        assert account_manager.load_accounts() == []
-        assert not accounts_file.exists()
+    def test_wrong_key_keeps_file(self, accounts_path, keyring_fake, manager):
+        """InvalidToken 路径：密钥不匹配时文件保留，修复密钥环后可恢复"""
+        manager.save_accounts([AccountCredential(sessdata="s", bili_jct="j")])
+        keyring_fake.store["default_user"] = Fernet.generate_key().decode()  # 换掉密钥
+        assert manager.load_accounts() == []
+        assert accounts_path.exists()  # 文件不删除
 
-    def test_non_list_json_returns_empty(self, accounts_file, mock_fernet):
+    def test_keyring_unavailable_skips_disk_write(self, accounts_path, keyring_fake, manager):
+        """密钥环完全不可用时：密钥仅会话内有效，跳过写盘以避免产生无法解密的文件"""
+        keyring_fake.fail_get = True
+        keyring_fake.fail_set = True
+        manager.save_accounts([AccountCredential(sessdata="s", bili_jct="j")])
+        assert not accounts_path.exists()
+
+    def test_corrupted_json_backed_up(self, accounts_path, keyring_fake, manager):
+        """JSONDecodeError 路径：文件损坏时备份为 .corrupt"""
+        key, _ = manager._get_encryption_key()
+        accounts_path.write_bytes(Fernet(key).encrypt(b"not-json"))
+        assert manager.load_accounts() == []
+        assert not accounts_path.exists()
+        assert accounts_path.with_suffix(".json.corrupt").exists()
+
+    def test_non_list_json_backed_up(self, accounts_path, keyring_fake, manager):
         """如果加密内容是 dict 而非 list"""
-        fernet = mock_fernet
-        encrypted = fernet.encrypt(json.dumps({"bad": "data"}).encode())
-        accounts_file.write_bytes(encrypted)
-        assert account_manager.load_accounts() == []
-        assert not accounts_file.exists()
+        key, _ = manager._get_encryption_key()
+        accounts_path.write_bytes(Fernet(key).encrypt(json.dumps({"bad": "data"}).encode()))
+        assert manager.load_accounts() == []
+        assert accounts_path.with_suffix(".json.corrupt").exists()
 
-    def test_malformed_entry_skipped(self, accounts_file, mock_fernet):
+    def test_malformed_entry_skipped(self, accounts_path, keyring_fake, manager):
         """列表中混入格式异常的条目应被跳过"""
-        fernet = mock_fernet
+        key, _ = manager._get_encryption_key()
+        fernet = Fernet(key)
         data = [
             {"sessdata": "ok", "bili_jct": "ok"},              # 合法
-            {"bad_field": True},                                 # 缺少必填字段
+            {"sessdata": 123, "bili_jct": 456},                                 # 字段类型错误（pydantic v2 不做 int→str 协变）
             {"sessdata": "ok2", "bili_jct": "ok2", "uid": 3},   # 合法
         ]
-        encrypted = fernet.encrypt(json.dumps(data).encode())
-        accounts_file.write_bytes(encrypted)
-        loaded = account_manager.load_accounts()
-        assert len(loaded) == 2
+        accounts_path.write_bytes(fernet.encrypt(json.dumps(data).encode()))
+        assert len(manager.load_accounts()) == 2
 
 
 class TestSaveAccounts:
     """save_accounts"""
 
-    def test_empty_list_deletes_file(self, accounts_file, mock_fernet):
-        accounts_file.write_bytes(b"dummy")
-        account_manager.save_accounts([])
-        assert not accounts_file.exists()
+    def test_empty_list_deletes_file(self, accounts_path, keyring_fake, manager):
+        accounts_path.write_bytes(b"dummy")
+        manager.save_accounts([])
+        assert not accounts_path.exists()
 
-    def test_empty_list_no_file_no_error(self, accounts_file, mock_fernet):
-        account_manager.save_accounts([])
+    def test_empty_list_no_file_no_error(self, accounts_path, keyring_fake, manager):
+        manager.save_accounts([])
 
-    def test_save_creates_encrypted_file(self, accounts_file, mock_fernet):
+    def test_save_creates_encrypted_file(self, accounts_path, keyring_fake, manager):
         accounts = [AccountCredential(sessdata="s", bili_jct="j")]
-        account_manager.save_accounts(accounts)
-        assert accounts_file.exists()
+        manager.save_accounts(accounts)
+        assert accounts_path.exists()
         # 文件内容不应是明文
-        raw = accounts_file.read_bytes()
+        raw = accounts_path.read_bytes()
         assert b"sessdata" not in raw
+        # 密钥应已持久化到密钥环
+        assert "default_user" in keyring_fake.store


### PR DESCRIPTION
- tests/ 中 14 个文件的 danmaku_sender.core.* 旧包名全部映射到分层后的新路径
- test_state 移除 VideoState 用例，改为 QueueState 队列操作测试
- test_account_manager 适配 AccountManager 类 API（密钥环 fake、损坏备份、密钥未持久化跳过写盘）
- calc_eta/SenderConfig 校验测试适配新签名（burst_enabled 门控）
- 新增 test_repo/test_history_manager：存证落库/冲突忽略/核销/标记丢失/统计基线/断点续传计数
- 新增 test_pipeline_record：发送成功必须落库（2026-09 存证静默丢失事故回归），失败不产生存证
- 新增 test.yml：push(main)/PR 自动运行 pytest

## Summary by Sourcery

更新并扩展测试体系以适配架构重构、验证历史存证可靠性，并在 CI 中自动执行完整测试套件。

Bug Fixes:
- 修复重构后测试套件中的失效导入、API 适配和状态模型测试。
- 新增发送存证回归覆盖，确保成功发送写入历史记录且失败发送不产生存证。

Enhancements:
- 补充 HistoryManager 的落库、去重、核销、丢失标记、统计基线和断点续传计数测试。
- 将状态测试更新为覆盖 QueueState 队列操作与状态信号。
- 完善 AccountManager 加密存储测试，覆盖密钥环异常、损坏备份和无持久化密钥时跳过写盘。

CI:
- 新增 GitHub Actions 测试工作流，在 main 推送和 Pull Request 中自动运行 pytest。

Tests:
- 更新现有测试以匹配重构后的分层包路径、配置签名和服务 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新并扩展测试体系以适配架构重构、验证历史存证可靠性，并在 CI 中自动执行完整测试套件。

Bug Fixes:
- 修复重构后测试套件中的失效导入、API 适配和状态模型测试。
- 新增发送存证回归覆盖，确保成功发送写入历史记录且失败发送不产生存证。

Enhancements:
- 补充 HistoryManager 的落库、去重、核销、丢失标记、统计基线和断点续传计数测试。
- 将状态测试更新为覆盖 QueueState 队列操作与状态信号。
- 完善 AccountManager 加密存储测试，覆盖密钥环异常、损坏备份和无持久化密钥时跳过写盘。

CI:
- 新增 GitHub Actions 测试工作流，在 main 推送和 Pull Request 中自动运行 pytest。

Tests:
- 更新现有测试以匹配重构后的分层包路径、配置签名和服务 API。

</details>

<details>
<summary>Original summary in English</summary>



</details>